### PR TITLE
[BUG] Fix SQL syntax error when the database name includes `-` character

### DIFF
--- a/mine/Command/InstallProjectCommand.php
+++ b/mine/Command/InstallProjectCommand.php
@@ -251,7 +251,7 @@ class InstallProjectCommand extends MineCommand
             $pdo = new \PDO($dsn, $this->database['dbuser'], $this->database['dbpass']);
             $isSuccess = $pdo->query(
                 sprintf(
-                    'CREATE DATABASE IF NOT EXISTS %s DEFAULT CHARSET %s COLLATE %s_general_ci;',
+                    'CREATE DATABASE IF NOT EXISTS `%s` DEFAULT CHARSET %s COLLATE %s_general_ci;',
                     $this->database['dbname'], $this->database['charset'], $this->database['charset']
                 )
             );


### PR DESCRIPTION
Steps to reproduce:
1. run `php bin/hyperf.php mine:install` to init the mineadmin
2. input a database name that includes `-` character, likes `mineadmin-web`

Error:
```
SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-web DEFAULT CHARSET utf8mb4 COLLATE utf8mb4_general_ci' at line 1
```