### PR TITLE
使用mine:migrate-gen 生成数据表时，输入了应用名，根据数据库设计规范，自动生成迁移文件名

### DIFF
--- a/mine/Command/Migrate/MineMigrate.php
+++ b/mine/Command/Migrate/MineMigrate.php
@@ -56,8 +56,6 @@ class MineMigrate extends BaseCommand
         // It's possible for the developer to specify the tables to modify in this
         // schema operation. The developer may also specify if this table needs
         // to be freshly created so we can create the appropriate migrations.
-        $name = 'create_' . Str::snake(trim($this->input->getArgument('name'))).'_table';
-
         $this->module = $this->input->getOption('module');
 
         if (empty($this->module)) {
@@ -66,6 +64,8 @@ class MineMigrate extends BaseCommand
         }
 
         $this->module = ucfirst($this->module);
+        
+        $name = 'create_' . Str::snake($this->module . ucfirst(trim($this->input->getArgument('name')))).'_table';
 
         $table = $this->input->getOption('table');
 


### PR DESCRIPTION
使用mine:migrate-gen 生成数据表时，输入了应用名，根据数据库设计规范，自动生成迁移文件名