### PR TITLE
优化导入导出方法的使用-增加phpstorm配置

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PHPSTORM_META{
+    // Reflect
+    override(\Psr\Container\ContainerInterface::get(0), map('@'));
+    override(\Hyperf\Utils\Context::get(0), map('@'));
+    override(\make(0), map('@'));
+    override(\di(0), map('@'));
+}
+
+namespace Hyperf\Database\Model{
+    class Builder{
+        /**
+         * @param int|null $userid
+         * @return Builder
+         */
+        public function userDataScope(?int $userid = null)
+        {
+
+        }
+    }
+}

--- a/mine/Annotation/ExcelProperty.php
+++ b/mine/Annotation/ExcelProperty.php
@@ -81,4 +81,9 @@ class ExcelProperty extends AbstractAnnotation
      * @var string
      */
     public string $dictName;
+    /**
+     * 数据路径 用法: object.value
+     * @var string
+     */
+    public string $path;
 }

--- a/mine/MineCollection.php
+++ b/mine/MineCollection.php
@@ -98,7 +98,7 @@ class MineCollection extends Collection
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \Psr\Container\NotFoundExceptionInterface
      */
-    public function export(string $dto, string $filename, array|\Closure $closure = null): \Psr\Http\Message\ResponseInterface
+    public function export(string $dto, string $filename, array|\Closure $closure = null, \Closure $callbackData = null): \Psr\Http\Message\ResponseInterface
     {
         $excelDrive = config('mineadmin.excel_drive');
         if ($excelDrive === 'auto') {
@@ -106,7 +106,7 @@ class MineCollection extends Collection
         } else {
             $excel = $excelDrive === 'xlsWriter' ? new XlsWriter($dto) : new PhpOffice($dto);
         }
-        return $excel->export($filename, is_null($closure) ? $this->toArray() : $closure);
+        return $excel->export($filename, is_null($closure) ? $this->toArray() : $closure, $callbackData);
     }
 
     /**

--- a/mine/MineModelVisitor.php
+++ b/mine/MineModelVisitor.php
@@ -32,6 +32,7 @@ class MineModelVisitor extends  Visitor
             'decimal' => 'decimal:2',
             'float', 'double', 'real' => 'float',
             'bool', 'boolean' => 'boolean',
+            'json' => 'array',
             default => null,
         };
     }
@@ -53,8 +54,6 @@ class MineModelVisitor extends  Visitor
             case 'date':
             case 'datetime':
                 return '\Carbon\Carbon';
-            case 'array':
-                return 'json';
             case 'json':
                 return 'array';
         }

--- a/mine/Office/Excel/PhpOffice.php
+++ b/mine/Office/Excel/PhpOffice.php
@@ -85,7 +85,7 @@ class PhpOffice extends MineExcel implements ExcelPropertyInterface
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \Psr\Container\NotFoundExceptionInterface
      */
-    public function export(string $filename, array|\Closure $closure): \Psr\Http\Message\ResponseInterface
+    public function export(string $filename, array|\Closure $closure, \Closure $callbackData = null): \Psr\Http\Message\ResponseInterface
     {
         $spread = new Spreadsheet();
         $sheet  = $spread->getActiveSheet();
@@ -122,7 +122,8 @@ class PhpOffice extends MineExcel implements ExcelPropertyInterface
             $row = 2;
             while ($generate->valid()) {
                 $column = 'A';
-                foreach ($generate->current() as $name => $value) {
+                $items = $generate->current();
+                foreach ($items as $name => $value) {
                     $columnRow = $column . $row;
                     $annotation = '';
                     foreach ($this->property as $item) {
@@ -134,8 +135,12 @@ class PhpOffice extends MineExcel implements ExcelPropertyInterface
 
                     if (!empty($annotation['dictName'])) {
                         $sheet->setCellValue($columnRow, $annotation['dictName'][$value]);
+                    } else if (!empty($annotation['path'])){
+                        $sheet->setCellValue($columnRow, data_get($items, $annotation['path']));
                     } else if (!empty($annotation['dictData'])) {
                         $sheet->setCellValue($columnRow, $annotation['dictData'][$value]);
+                    } else if(!empty($this->dictData[$name])){
+                        $sheet->setCellValue($columnRow, $this->dictData[$name][$value] ?? '');
                     } else {
                         $sheet->setCellValue($columnRow, $value . "\t");
                     }

--- a/mine/Office/Excel/XlsWriter.php
+++ b/mine/Office/Excel/XlsWriter.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Mine\Office\Excel;
 
+use Hyperf\HttpMessage\Stream\SwooleStream;
+use MathPHP\Probability\Distribution\Continuous\F;
 use Mine\Exception\MineException;
 use Mine\MineResponse;
 use Mine\Office\ExcelPropertyInterface;
@@ -21,6 +23,15 @@ use Vtiful\Kernel\Format;
 
 class XlsWriter extends MineExcel implements ExcelPropertyInterface
 {
+    public static function getSheetData(mixed $request)
+    {
+        $file = $request->file('file');
+        $tempFileName = 'import_' . time() . '.' . $file->getExtension();
+        $tempFilePath = BASE_PATH . '/runtime/' . $tempFileName;
+        file_put_contents($tempFilePath, $file->getStream()->getContents());
+        $xlsxObject = new \Vtiful\Kernel\Excel(['path' => BASE_PATH . '/runtime/']);
+        return $xlsxObject->openFile($tempFileName)->openSheet()->getSheetData();
+    }
 
     /**
      * 导入数据
@@ -79,7 +90,7 @@ class XlsWriter extends MineExcel implements ExcelPropertyInterface
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \Psr\Container\NotFoundExceptionInterface
      */
-    public function export(string $filename, array|\Closure $closure): \Psr\Http\Message\ResponseInterface
+    public function export(string $filename, array|\Closure $closure, \Closure $callbackData = null): \Psr\Http\Message\ResponseInterface
     {
         $filename .= '.xlsx';
         is_array($closure) ? $data = &$closure : $data = $closure();
@@ -93,6 +104,7 @@ class XlsWriter extends MineExcel implements ExcelPropertyInterface
         $columnName  = [];
         $columnField = [];
         foreach ($this->property as $item) {
+
             $columnName[]  = $item['value'];
             $columnField[] = $item['name'];
         }
@@ -126,10 +138,12 @@ class XlsWriter extends MineExcel implements ExcelPropertyInterface
                 ->border(Format::BORDER_THIN)
                 ->toResource()
         );
-
         $exportData = [];
         foreach ($data as $item) {
             $yield = [];
+            if ($callbackData) {
+                $item = $callbackData($item);
+            }
             foreach ($this->property as $property) {
                 foreach ($item as $name => $value) {
                     if ($property['name'] == $name) {
@@ -137,6 +151,10 @@ class XlsWriter extends MineExcel implements ExcelPropertyInterface
                             $yield[] = $property['dictName'][$value];
                         } else if (!empty($property['dictData'])) {
                             $yield[] = $property['dictData'][$value];
+                        }else if (!empty($property['path'])){
+                            $yield[] = data_get($item, $property['path']);
+                        }else if(!empty($this->dictData[$name])){
+                            $yield[] = $this->dictData[$name][$value] ?? '';
                         } else {
                             $yield[] = $value;
                         }

--- a/mine/Office/Excel/XlsWriter.php
+++ b/mine/Office/Excel/XlsWriter.php
@@ -103,8 +103,8 @@ class XlsWriter extends MineExcel implements ExcelPropertyInterface
 
         $columnName  = [];
         $columnField = [];
-        foreach ($this->property as $item) {
 
+        foreach ($this->property as $item) {
             $columnName[]  = $item['value'];
             $columnField[] = $item['name'];
         }

--- a/mine/Office/MineExcel.php
+++ b/mine/Office/MineExcel.php
@@ -35,18 +35,21 @@ abstract class MineExcel
      * @var array
      */
     protected array $property = [];
+    protected array $dictData = [];
 
 
     /**
      * @param String $dto
-     * @throws ContainerExceptionInterface
-     * @throws NotFoundExceptionInterface
-     * @throws \RedisException
+     * @param MineModel $model
      */
     public function __construct(string $dto)
     {
         if (!(new $dto) instanceof MineModelExcel) {
             throw new MineException('dto does not implement an interface of the MineModelExcel', 500);
+        }
+        $dtoObject = new $dto();
+        if (method_exists($dtoObject, 'dictData')) {
+            $this->dictData = $dtoObject->dictData();
         }
         $this->annotationMate = AnnotationCollector::get($dto);
         $this->parseProperty();
@@ -92,9 +95,9 @@ abstract class MineExcel
                 'bgColor' => $mate[self::ANNOTATION_NAME]->bgColor ?? null,
                 'dictData' => $mate[self::ANNOTATION_NAME]->dictData,
                 'dictName' => empty($mate[self::ANNOTATION_NAME]->dictName) ? null : $this->getDictData($mate[self::ANNOTATION_NAME]->dictName),
+                'path' => $mate[self::ANNOTATION_NAME]->path ?? null,
             ];
         }
-
         ksort($this->property);
     }
 

--- a/mine/Traits/ServiceTrait.php
+++ b/mine/Traits/ServiceTrait.php
@@ -292,7 +292,7 @@ trait ServiceTrait
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \Psr\Container\NotFoundExceptionInterface
      */
-    public function export(array $params, ?string $dto, string $filename = null): ResponseInterface
+    public function export(array $params, ?string $dto, string $filename = null, \Closure $callbackData = null): ResponseInterface
     {
         if (empty($dto)) {
             return container()->get(MineResponse::class)->error('导出未指定DTO');
@@ -302,7 +302,7 @@ trait ServiceTrait
             $filename = $this->mapper->getModel()->getTable();
         }
 
-        return (new MineCollection())->export($dto, $filename, $this->mapper->getList($params));
+        return (new MineCollection())->export($dto, $filename, $this->mapper->getList($params), $callbackData);
     }
 
     /**


### PR DESCRIPTION
```
<?php
namespace App\Open\Dto;

use App\Open\Service\OpenCapitalClassifyService;
use Mine\Interfaces\MineModelExcel;
use Mine\Annotation\ExcelData;
use Mine\Annotation\ExcelProperty;

/**
 * 买家资金流水Dto （导入导出）
 */
#[ExcelData]
class OpenPurchaseCapitalDto implements MineModelExcel
{
    public function dictData()
    {
        return [
          'classify' => array_column(make(OpenCapitalClassifyService::class)->getList([
              'is_purchase_action' => 1,
          ]), 'name', 'id'),
        ];
    }

    #[ExcelProperty(value: "ID", index: 0)]
    public string $id;

    #[ExcelProperty(value: "操作类型",dictData: [1=>'增加', 2 => '减少'], index: 1)]
    public string $type;

    #[ExcelProperty(value: "来源/去向", dictData: [1 => '资金', 2 => '订单'], index: 2)]
    public string $option;

    #[ExcelProperty(value: "流水订单号", index: 3)]
    public string $number;

    #[ExcelProperty(value: "来源订单号", index: 4)]
    public string $order_id;

    #[ExcelProperty(value: "操作金额", index: 5)]
    public string $amount;

    #[ExcelProperty(value: "商户", index: 6, path: "purchase_info.name")]
    public string $purchase_id;

    #[ExcelProperty(value: "备注", index: 7)]
    public string $remark;

    #[ExcelProperty(value: "状态", dictData: ['0' => '处理中', 1 => '完成', 2 => '失败'], index: 8)]
    public string $status;

    #[ExcelProperty(value: "创建人",path: 'create_user.nickname', index: 9)]
    public string $created_by;

    #[ExcelProperty(value: "创建时间", index: 10)]
    public string $created_at;

    #[ExcelProperty(value: "资金归类", index: 11)]
    public string $classify;

}
```
```
  public function dictData()
    {
        return [
          'classify' => array_column(make(OpenCapitalClassifyService::class)->getList([
              'is_purchase_action' => 1,
          ]), 'name', 'id'),
        ];
    }
```
### 当字段需要从另一张表中取出关联数据 就可以如上编写代码
