### PR TITLE
Repair some files generated when table prefix is not null automatically with table prefix.

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -5,3 +5,4 @@
 ### Fixes
 
 - [#205](https://github.com/mineadmin/MineAdmin/pull/205) Specifying swagger component version
+- [#218](https://github.com/mineadmin/MineAdmin/pull/218) Repair some files generated when table prefix is not null automatically with table prefix.

--- a/CHANGELOG-2.0.zh_CN.md
+++ b/CHANGELOG-2.0.zh_CN.md
@@ -5,3 +5,4 @@
 ### 修复
 
 - [#205](https://github.com/mineadmin/MineAdmin/pull/205) 指定 swagger 组件版本
+- [#218](https://github.com/mineadmin/MineAdmin/pull/218) 修复表前缀不为空时生成的某些文件自动带上了表前缀

--- a/app/Setting/Service/SettingGenerateTablesService.php
+++ b/app/Setting/Service/SettingGenerateTablesService.php
@@ -100,7 +100,7 @@ class SettingGenerateTablesService extends AbstractService
                 ]
             );
             $tableInfo = [
-                'table_name' => $item['name'],
+                'table_name' => str_replace(env('DB_PREFIX'), '', $item['name']),
                 'table_comment' => $item['comment'],
                 'menu_name' => $item['comment'],
                 'type' => 'single',

--- a/app/Setting/Service/SettingGenerateTablesService.php
+++ b/app/Setting/Service/SettingGenerateTablesService.php
@@ -100,7 +100,7 @@ class SettingGenerateTablesService extends AbstractService
                 ]
             );
             $tableInfo = [
-                'table_name' => str_replace(env('DB_PREFIX'), '', $item['name']),
+                'table_name' => env('DB_PREFIX') ? str_replace(env('DB_PREFIX'), '', $item['name']) : $item['name'],
                 'table_comment' => $item['comment'],
                 'menu_name' => $item['comment'],
                 'type' => 'single',


### PR DESCRIPTION
修复表前缀不为空时生成的某些文件自动带上了表前缀