### PR TITLE
修改用户更新个人资料过滤不存在的字段、修复手机号码验证传递null会报错的问题

### DIFF
--- a/app/System/Listener/ValidatorFactoryResolvedListener.php
+++ b/app/System/Listener/ValidatorFactoryResolvedListener.php
@@ -34,6 +34,10 @@ class ValidatorFactoryResolvedListener implements ListenerInterface
         $validatorFactory = $event->validatorFactory;
 
         $validatorFactory->extend('phone_number', function (string $attribute, mixed $value, array $parameters, Validator $validator): bool {
+            if (! $value) {
+                return false;
+            }
+
             return (bool) preg_match('/^1[3-9]\d{9}$/', $value);
         });
     }

--- a/app/System/Mapper/SystemUploadFileMapper.php
+++ b/app/System/Mapper/SystemUploadFileMapper.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace App\System\Mapper;
 
-use App\System\Model\SystemLoginLog;
 use App\System\Model\SystemUploadfile;
 use Hyperf\Database\Model\Builder;
 use Hyperf\Di\Annotation\Inject;
@@ -89,7 +88,7 @@ class SystemUploadFileMapper extends AbstractMapper
         foreach ($ids as $id) {
             $model = $this->model::withTrashed()->find($id);
             if ($model) {
-                $storageMode = match ((string)$model->storage_mode) {
+                $storageMode = match ((string) $model->storage_mode) {
                     '1' => 'local',
                     '2' => 'oss',
                     '3' => 'qiniu',

--- a/app/System/Mapper/SystemUploadFileMapper.php
+++ b/app/System/Mapper/SystemUploadFileMapper.php
@@ -28,7 +28,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 class SystemUploadFileMapper extends AbstractMapper
 {
     /**
-     * @var SystemLoginLog
+     * @var SystemUploadfile
      */
     public $model;
 
@@ -89,7 +89,7 @@ class SystemUploadFileMapper extends AbstractMapper
         foreach ($ids as $id) {
             $model = $this->model::withTrashed()->find($id);
             if ($model) {
-                $storageMode = match ($model->storage_mode) {
+                $storageMode = match ((string)$model->storage_mode) {
                     '1' => 'local',
                     '2' => 'oss',
                     '3' => 'qiniu',

--- a/app/System/Service/SystemUserService.php
+++ b/app/System/Service/SystemUserService.php
@@ -259,14 +259,11 @@ class SystemUserService extends AbstractService implements UserServiceInterface
             return false;
         }
 
-        $model = $this->mapper->getModel()::find($params['id']);
+        $id = $params['id'];
         unset($params['id'], $params['password']);
-        foreach ($params as $key => $param) {
-            $model[$key] = $param;
-        }
+        $this->clearCache((string) $id);
 
-        $this->clearCache((string) $model['id']);
-        return $model->save();
+        return $this->mapper->update($id, $params);
     }
 
     /**


### PR DESCRIPTION
修改用户更新个人资料过滤不存在的字段（前端传递其他不存在字段会报错）、修复手机号码验证传递null会报错的问题（手机号码不填，前端传递的值为null，preg_match第二个参数必须是string）