### PR TITLE
FIX: 修复多点登录模式下，token缓存复用 和 在线用户监控列表问题

### DIFF
--- a/app/System/Listener/LoginListener.php
+++ b/app/System/Listener/LoginListener.php
@@ -22,6 +22,7 @@ use Mine\Helper\Str;
 use Mine\MineRequest;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use Xmo\JWTAuth\JWT;
 
 /**
  * Class LoginListener.
@@ -60,10 +61,20 @@ class LoginListener implements ListenerInterface
             'login_time' => date('Y-m-d H:i:s'),
         ]);
 
-        $key = sprintf('%sToken:%s', config('cache.default.prefix'), $event->userinfo['id']);
-
-        $redis->del($key);
-        ($event->loginStatus && $event->token) && $redis->set($key, $event->token, config('jwt.ttl'));
+        if ($event->loginStatus && $event->token) {
+            # 多点登录情况下，只保存一个key会导致最近时刻登录的用户如果登出之后,则该用户不会出现在在线用户监控列表中
+            # 利用 token 设置jwt的jti 来做多点登录token的判断
+            $jwt = container()->get(JWT::class);
+            $parserData = $jwt->getParserData($event->token);
+            $scene = $parserData['jwt_scene'];
+            $config = $jwt->getSceneConfig($scene);
+            $key = match ($config['login_type']) {
+                'sso' => sprintf('%sToken:%s', config('cache.default.prefix'), $event->userinfo['id']),
+                'mpop' => sprintf('%sToken:%s:%s', config('cache.default.prefix'), $event->userinfo['id'], $parserData['jti']),
+            };
+            $redis->del($key);
+            $redis->set($key, $event->token, config('jwt.ttl'));
+        }
 
         if ($event->loginStatus) {
             $event->userinfo['login_ip'] = $ip;

--- a/app/System/Service/SystemUserService.php
+++ b/app/System/Service/SystemUserService.php
@@ -128,7 +128,8 @@ class SystemUserService extends AbstractService implements UserServiceInterface
         while (false !== ($users = $redis->scan($iterator, $key, 100))) {
             foreach ($users as $user) {
                 // 如果是已经加入到黑名单的就代表不是登录状态了
-                if (! $this->hasTokenBlack($redis->get($user)) && preg_match("/{$key}(\\d+)$/", $user, $match) && isset($match[1])) {
+                // 重写正则 用来 匹配 多点登录 使用的token的key
+                if (! $this->hasTokenBlack($redis->get($user)) && preg_match('/:(\d+)(:|$)/', $user, $match) && isset($match[1])) {
                     $userIds[] = $match[1];
                 }
             }
@@ -190,13 +191,21 @@ class SystemUserService extends AbstractService implements UserServiceInterface
     public function kickUser(string $id): bool
     {
         $redis = redis();
-        $key = sprintf('%sToken:%s', config('cache.default.prefix'), $id);
-        $token = $redis->get($key);
-        if (! is_string($token)) {
-            throw new MineException(t('system.not_user_token'));
+        // 保证获取到所有token，方便一次性全部下线。
+        $key = sprintf('%sToken:%s*', config('cache.default.prefix'), $id);
+        while (false !== ($users = $redis->scan($iterator, $key, 100))) {
+            $jwt = $this->container->get(JWT::class);
+            foreach ($users as $user) {
+                $token = $redis->get($user);
+                if (! is_string($token)) {
+                    continue;
+                }
+                $scene = $jwt->getParserData($token)['jwt_scene'];
+                $jwt->logout($token, $scene);
+                $redis->del($user);
+            }
+            unset($users);
         }
-        user()->getJwt()->logout($redis->get($key), 'default');
-        $redis->del($key);
         return true;
     }
 
@@ -344,16 +353,16 @@ class SystemUserService extends AbstractService implements UserServiceInterface
 
     private function hasTokenBlack(string $token): bool
     {
+        # token解析的数据有scene信息，只需要判断当前token在对应场景下是否有黑名单
         $jwt = $this->container->get(JWT::class);
+        $scene = $jwt->getParserData($token)['jwt_scene'];
         $scenes = array_keys(config('jwt.scene'));
-        foreach ($scenes as $scene) {
-            $sceneJwt = $jwt->setScene($scene);
-            if ($sceneJwt->blackList->hasTokenBlack(
-                $sceneJwt->getParserData($token),
-                $jwt->getSceneConfig($scene)
-            )) {
-                return true;
-            }
+        $jti = $jwt->getParserData($token)['jti'];
+        if (in_array($scene, $scenes) && $jwt->setScene($scene)->blackList->hasTokenBlack(
+            $jwt->getParserData($token),
+            $jwt->getSceneConfig($scene)
+        )) {
+            return true;
         }
         return false;
     }


### PR DESCRIPTION
LoginListener.php: 修复因为多点登录复用同一个token导致该账号最近一次登录的设备登出就无法获得正确的用户在线情况
SystemUserService.php: 1. 重写 token-key 正则匹配 2. kickUser 保证获取到所有token，一次性全部下线。 3. hasTokenBlack 只判断传入token所在scene的情况，否则会导致判断多重scene而导致在线用户监控列表出错。