### PR TITLE
Fix: is_in_container函数现在能更好的检测是否在容器中

### DIFF
--- a/common/common.php
+++ b/common/common.php
@@ -130,11 +130,11 @@ if (! function_exists('delete_cache')) {
 if (! function_exists('is_in_container')) {
     function is_in_container(): bool
     {
-        if (! file_exists('/proc/self/mountinfo')) {
-            return false;
+        if (file_exists('/.dockerenv')) {
+            return true;
         }
-        $mountinfo = file_get_contents('/proc/self/mountinfo');
-        return strpos($mountinfo, 'kubepods') > 0 || strpos($mountinfo, 'docker') > 0;
+        $cgroup = file_get_contents('/proc/1/cgroup');
+        return strpos($cgroup, 'kubepods') > 0 || strpos($cgroup, 'docker') > 0;
     }
 }
 


### PR DESCRIPTION
修复之前，如果本机用Docker运行了任何东西，例如MySQL，但PHP和Swoole并没有在Docker里面跑，也会被认为是在容器中，现已修复该问题