### PR TITLE
fix dept level bug

### DIFF
--- a/app/System/Mapper/SystemDeptMapper.php
+++ b/app/System/Mapper/SystemDeptMapper.php
@@ -125,6 +125,17 @@ class SystemDeptMapper extends AbstractMapper
         return true;
     }
 
+    #[Transaction]
+    public function batchUpdate(array $update): bool
+    {
+        foreach ($update as $item) {
+            $result = parent::update($item['id'], $item['data']);
+            if (! $result) {
+                return false;
+            }
+        }
+        return true;
+    }
     /**
      * 查询部门名称.
      */
@@ -138,6 +149,12 @@ class SystemDeptMapper extends AbstractMapper
         return $this->model::withTrashed()->where('parent_id', $id)->exists();
     }
 
+    public function getDescendantsDepts(int $id): array
+    {
+        $params = ['level' => $id];
+        return $this->handleSearch($this->model::query(), $params)->get()->toArray();
+    }
+
     /**
      * 搜索处理器.
      */
@@ -145,6 +162,10 @@ class SystemDeptMapper extends AbstractMapper
     {
         if (isset($params['status']) && filled($params['status'])) {
             $query->where('status', $params['status']);
+        }
+
+        if (isset($params['level']) && filled($params['level'])) {
+            $query->where('level', 'like', '%' . $params['level'] . '%');
         }
 
         if (isset($params['name']) && filled($params['name'])) {

--- a/app/System/Mapper/SystemDeptMapper.php
+++ b/app/System/Mapper/SystemDeptMapper.php
@@ -136,6 +136,7 @@ class SystemDeptMapper extends AbstractMapper
         }
         return true;
     }
+
     /**
      * 查询部门名称.
      */

--- a/app/System/Mapper/SystemMenuMapper.php
+++ b/app/System/Mapper/SystemMenuMapper.php
@@ -207,9 +207,9 @@ class SystemMenuMapper extends AbstractMapper
     /**
      * 获取子孙menus.
      */
-    public function getDescendantsMenus(int $parentId): array
+    public function getDescendantsMenus(int $id): array
     {
-        $params = ['level' => $parentId];
+        $params = ['level' => $id];
         return $this->handleSearch($this->model::query(), $params)->get()->toArray();
     }
 


### PR DESCRIPTION
和 #244 menu同样问题，但是因为
`vendor/xmo/mine-core/src/Traits/ModelMacroTrait.php` 中 `getUserDataScope`里的代码逻辑，使用了 
120行
```php
->orWhere('level', 'like', $deptId . ',%')
->orWhere('level', 'like', '%,' . $deptId)
->orWhere('level', 'like', '%,' . $deptId . ',%');
```
建议尽早修复。

修改了部分可能导致歧义的参数名