### PR TITLE
jwt登录方式-历史遗留问题-login_type配置错误导致App\System\Listener的match 报错

### DIFF
--- a/app/System/Listener/LoginListener.php
+++ b/app/System/Listener/LoginListener.php
@@ -70,7 +70,7 @@ class LoginListener implements ListenerInterface
             $config = $jwt->getSceneConfig($scene);
             $key = match ($config['login_type']) {
                 'sso' => sprintf('%sToken:%s', config('cache.default.prefix'), $event->userinfo['id']),
-                'mpop' => sprintf('%sToken:%s:%s', config('cache.default.prefix'), $event->userinfo['id'], $parserData['jti']),
+                default => sprintf('%sToken:%s:%s', config('cache.default.prefix'), $event->userinfo['id'], $parserData['jti']),
             };
             $redis->del($key);
             $redis->set($key, $event->token, config('jwt.ttl'));

--- a/config/autoload/jwt.php
+++ b/config/autoload/jwt.php
@@ -112,7 +112,7 @@ return [
         ],
         'application3' => [
             'secret' => 'application3', // 非对称加密使用字符串,请使用自己加密的字符串
-            'login_type' => 'mppo', //  登录方式，sso为单点登录，mpop为多点登录
+            'login_type' => 'mpop', //  登录方式，sso为单点登录，mpop为多点登录
             'ttl' => 7200, // token过期时间，单位为秒
             'blacklist_cache_ttl' => env('JWT_TTL', 7200), // 黑名单缓存token时间，注意：该时间一定要设置比token过期时间要大一点，默认为100秒,最好设置跟过期时间一样
         ],


### PR DESCRIPTION
jwt登录方式-历史遗留问题-login_type配置错误导致App\System\Listener的match 报错，应使用default 避免报错