### PR TITLE
Fix: 修复默认语言是英语时,下载插件报错

### DIFF
--- a/storage/languages/en/app-store.php
+++ b/storage/languages/en/app-store.php
@@ -9,3 +9,9 @@ declare(strict_types=1);
  * @contact  root@imoi.cn
  * @license  https://github.com/mineadmin/MineAdmin/blob/master/LICENSE
  */
+return [
+    'access_token_null' => 'Access token not configured',
+    'store' => [
+        'response_fail' => 'Failed to request plugin server',
+    ],
+];


### PR DESCRIPTION
如果locale默认设置为en，在未配置 access token时，因英文翻译文件为空，执行mine-extension:download下载应用会异常退出。

报错如下：
`In FileLoader.php line 118:

  Hyperf\Translation\FileLoader::loadPath(): Return value must be of type array, int returned`