### PR TITLE
chore(@mineadmin/pro-table): 升级pro-table到1.0.21，pro-table重构工具栏，开放api可…

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
     "@imengyu/vue3-context-menu": "^1.4.2",
     "@mineadmin/echarts": "^1.0.1",
     "@mineadmin/form": "^1.0.20",
-    "@mineadmin/pro-table": "^1.0.20",
+    "@mineadmin/pro-table": "^1.0.21",
     "@mineadmin/search": "^1.0.19",
     "@mineadmin/table": "^1.0.23",
     "@vueuse/core": "^11.1.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^1.0.20
         version: 1.0.20(element-plus@2.8.6(vue@3.5.12(typescript@5.6.2)))(typescript@5.6.2)
       '@mineadmin/pro-table':
-        specifier: ^1.0.20
-        version: 1.0.20(element-plus@2.8.6(vue@3.5.12(typescript@5.6.2)))(typescript@5.6.2)
+        specifier: ^1.0.21
+        version: 1.0.21(element-plus@2.8.6(vue@3.5.12(typescript@5.6.2)))(typescript@5.6.2)
       '@mineadmin/search':
         specifier: ^1.0.19
         version: 1.0.19(element-plus@2.8.6(vue@3.5.12(typescript@5.6.2)))(typescript@5.6.2)
@@ -1732,8 +1732,8 @@ packages:
     peerDependencies:
       element-plus: ^2.0.0
 
-  '@mineadmin/pro-table@1.0.20':
-    resolution: {integrity: sha512-6a9WnI9Cj0Ne7NGhMqT6J/rD8dcR0kjoR2OCLFX5tJ4acbpbQbq8QPH8WT/+cpj3MzNQIszG3Ll3YFYzjFs0pg==}
+  '@mineadmin/pro-table@1.0.21':
+    resolution: {integrity: sha512-fLF/eq3OIoeTDdvOKoC95ocvAegUTPIIw1/nIBPGUTnx3UcC+p1wIRKTBxXcAxBUQyfNm3rkVWTm6YM2wGmDsA==}
     peerDependencies:
       element-plus: ^2.0.0
 
@@ -7527,7 +7527,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@mineadmin/pro-table@1.0.20(element-plus@2.8.6(vue@3.5.12(typescript@5.6.2)))(typescript@5.6.2)':
+  '@mineadmin/pro-table@1.0.21(element-plus@2.8.6(vue@3.5.12(typescript@5.6.2)))(typescript@5.6.2)':
     dependencies:
       element-plus: 2.8.6(vue@3.5.12(typescript@5.6.2))
       vue: 3.5.12(typescript@5.6.2)


### PR DESCRIPTION
…以插件形式扩展: `useProTableToolbar()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the `@mineadmin/pro-table` dependency, potentially introducing new features and improvements.
- **Bug Fixes**
	- The upgrade may include bug fixes associated with the previous version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->