### PR TITLE
build(deps): downgrade doctrine/dbal from 4.1 to 3.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     "mineadmin/upload": "3.0-RC"
   },
   "require-dev": {
-    "doctrine/dbal": "^4.1",
+    "doctrine/dbal": "^3.6",
     "fakerphp/faker": "^1.23",
     "friendsofphp/php-cs-fixer": "^3.0",
     "hyperf/devtool": "3.1.*",


### PR DESCRIPTION
- Change doctrine/dbal requirement from ^4.1 to ^3.6 in composer.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Downgraded the required version of the `doctrine/dbal` package in the development dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->