### PR TITLE
feat(menu): 更新菜单权限并添加数据中心相关权限

### DIFF
--- a/app/Http/Admin/Controller/AttachmentController.php
+++ b/app/Http/Admin/Controller/AttachmentController.php
@@ -48,7 +48,7 @@ final class AttachmentController extends AbstractController
         security: [['Bearer' => [], 'ApiKey' => []]],
         tags: ['数据中心'],
     )]
-    #[Permission(code: 'attachment:list')]
+    #[Permission(code: 'dataCenter:attachment:list')]
     #[PageResponse(instance: AttachmentSchema::class)]
     public function list(): Result
     {
@@ -69,7 +69,7 @@ final class AttachmentController extends AbstractController
         security: [['Bearer' => [], 'ApiKey' => []]],
         tags: ['数据中心'],
     )]
-    #[Permission(code: 'attachment:upload')]
+    #[Permission(code: 'dataCenter:attachment:upload')]
     #[ResultResponse(instance: new Result())]
     public function upload(UploadRequest $request): Result
     {
@@ -86,7 +86,7 @@ final class AttachmentController extends AbstractController
         path: '/admin/attachment/{id}',
         operationId: 'DeleteAttachment',
     )]
-    #[Permission(code: 'attachment:delete')]
+    #[Permission(code: 'dataCenter:attachment:delete')]
     #[ResultResponse(instance: new Result())]
     public function delete(int $id): Result
     {

--- a/databases/seeders/menu_update_20241029.php
+++ b/databases/seeders/menu_update_20241029.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of MineAdmin.
+ *
+ * @link     https://www.mineadmin.com
+ * @document https://doc.mineadmin.com
+ * @contact  root@imoi.cn
+ * @license  https://github.com/mineadmin/MineAdmin/blob/master/LICENSE
+ */
+use App\Model\Permission\Menu;
+use App\Model\Permission\Meta;
+use Hyperf\Database\Seeders\Seeder;
+use Hyperf\DbConnection\Db;
+
+class MenuUpdate20241029 extends Seeder
+{
+    public const BASE_DATA = [
+        'name' => '',
+        'path' => '',
+        'component' => '',
+        'redirect' => '',
+        'created_by' => 0,
+        'updated_by' => 0,
+        'remark' => '',
+    ];
+
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        if (env('DB_DRIVER') === 'odbc-sql-server') {
+            Db::unprepared('SET IDENTITY_INSERT [' . Menu::getModel()->getTable() . '] ON;');
+        }
+        $this->create($this->data());
+        if (env('DB_DRIVER') === 'odbc-sql-server') {
+            Db::unprepared('SET IDENTITY_INSERT [' . Menu::getModel()->getTable() . '] OFF;');
+        }
+    }
+
+    public function data(): array
+    {
+        return [
+            [
+                'name' => 'dataCenter',
+                'path' => '/dataCenter',
+                'meta' => new Meta([
+                    'title' => '数据中心',
+                    'i18n' => 'baseMenu.dataCenter.index',
+                    'icon' => 'ri:database-line',
+                    'type' => 'M',
+                    'hidden' => 1,
+                    'componentPath' => 'modules/',
+                    'componentSuffix' => '.vue',
+                    'breadcrumbEnable' => 1,
+                    'copyright' => 1,
+                    'cache' => 1,
+                    'affix' => 0,
+                ]),
+                'children' => [
+                    [
+                        'name' => 'dataCenter:attachment',
+                        'path' => '/dataCenter/attachment',
+                        'component' => 'base/views/dataCenter/attachment/index',
+                        'meta' => new Meta([
+                            'title' => '附件管理',
+                            'type' => 'M',
+                            'hidden' => 1,
+                            'icon' => 'ri:attachment-line',
+                            'i18n' => 'baseMenu.dataCenter.attachment',
+                            'componentPath' => 'modules/',
+                            'componentSuffix' => '.vue',
+                            'breadcrumbEnable' => 1,
+                            'copyright' => 1,
+                            'cache' => 1,
+                            'affix' => 0,
+                        ]),
+                        'children' => [
+                            [
+                                'name' => 'dataCenter:attachment:list',
+                                'meta' => new Meta([
+                                    'title' => '附件列表',
+                                    'i18n' => 'baseMenu.dataCenter.attachmentList',
+                                    'type' => 'B',
+                                ]),
+                            ],
+                            [
+                                'name' => 'dataCenter:attachment:upload',
+                                'meta' => new Meta([
+                                    'title' => '上传附件',
+                                    'i18n' => 'baseMenu.dataCenter.attachmentUpload',
+                                    'type' => 'B',
+                                ]),
+                            ],
+                            [
+                                'name' => 'dataCenter:attachment:delete',
+                                'meta' => new Meta([
+                                    'title' => '删除附件',
+                                    'i18n' => 'baseMenu.dataCenter.attachmentDelete',
+                                    'type' => 'B',
+                                ]),
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function create(array $data, int $parent_id = 0): void
+    {
+        foreach ($data as $v) {
+            $_v = $v;
+            if (isset($v['children'])) {
+                unset($_v['children']);
+            }
+            $_v['parent_id'] = $parent_id;
+            $menu = Menu::create(array_merge(self::BASE_DATA, $_v));
+            if (isset($v['children']) && count($v['children'])) {
+                $this->create($v['children'], $menu->id);
+            }
+        }
+    }
+}

--- a/tests/Feature/Admin/DataCenter/AttachmentControllerTest.php
+++ b/tests/Feature/Admin/DataCenter/AttachmentControllerTest.php
@@ -28,7 +28,7 @@ final class AttachmentControllerTest extends ControllerCase
     {
         $token = $this->token;
         $url = '/admin/attachment/list';
-        $code = 'attachment:list';
+        $code = 'dataCenter:attachment:list';
         $result = $this->get($url);
         $enforce = $this->getEnforce();
         self::assertSame(Arr::get($result, 'code'), ResultCode::UNAUTHORIZED->value);
@@ -68,7 +68,7 @@ final class AttachmentControllerTest extends ControllerCase
             'remark' => $faker->sentence,
         ]);
         $url = '/admin/attachment';
-        $code = 'attachment:delete';
+        $code = 'dataCenter:attachment:delete';
         $enforce = $this->getEnforce();
         $result = $this->delete($url . '/' . $entity->id);
         self::assertSame(Arr::get($result, 'code'), ResultCode::UNAUTHORIZED->value);


### PR DESCRIPTION
- 修改附件管理相关权限代码，增加 dataCenter前缀
- 添加数据中心菜单及其子菜单项
- 更新相关测试用例以匹配新的权限代码

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated permission codes for attachment management methods to better categorize permissions.
  - Introduced a new database seeder for populating menu-related data, including hierarchical menu structure.

- **Bug Fixes**
  - Adjusted test cases to reflect updated permission codes for attachment actions, ensuring accurate authorization checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->