### PR TITLE
refactor(ma-table)：升级到1.0.25版，优化列头对齐未指定下默认使用单元格对齐

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -23,7 +23,7 @@
     "@mineadmin/form": "^1.0.20",
     "@mineadmin/pro-table": "^1.0.22",
     "@mineadmin/search": "^1.0.19",
-    "@mineadmin/table": "^1.0.23",
+    "@mineadmin/table": "^1.0.25",
     "@vueuse/core": "^11.1.0",
     "@vueuse/integrations": "^11.1.0",
     "animate.css": "^4.1.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^1.0.19
         version: 1.0.19(element-plus@2.8.6(vue@3.5.12(typescript@5.6.2)))(typescript@5.6.2)
       '@mineadmin/table':
-        specifier: ^1.0.23
-        version: 1.0.23(element-plus@2.8.6(vue@3.5.12(typescript@5.6.2)))(typescript@5.6.2)
+        specifier: ^1.0.25
+        version: 1.0.25(element-plus@2.8.6(vue@3.5.12(typescript@5.6.2)))(typescript@5.6.2)
       '@vueuse/core':
         specifier: ^11.1.0
         version: 11.1.0(vue@3.5.12(typescript@5.6.2))
@@ -1742,8 +1742,8 @@ packages:
     peerDependencies:
       element-plus: ^2.0.0
 
-  '@mineadmin/table@1.0.23':
-    resolution: {integrity: sha512-MgcUESYiBOfuT3H2WEIo0EENaTagMc9+zpg6g4GYKdxGiq2vHVO8ZWBerB+s7f1r3tQFMjHFqGbA91hzZlGqiw==}
+  '@mineadmin/table@1.0.25':
+    resolution: {integrity: sha512-iPWhCVbTzE8pr21dQqrnXnwcdIM0LCjd1HbH9ZF04LOZn7+0U4LWZvoHy7bVq3yyQo7SGZBqV61Zajeyrddo7A==}
     peerDependencies:
       element-plus: ^2.0.0
 
@@ -7541,7 +7541,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@mineadmin/table@1.0.23(element-plus@2.8.6(vue@3.5.12(typescript@5.6.2)))(typescript@5.6.2)':
+  '@mineadmin/table@1.0.25(element-plus@2.8.6(vue@3.5.12(typescript@5.6.2)))(typescript@5.6.2)':
     dependencies:
       element-plus: 2.8.6(vue@3.5.12(typescript@5.6.2))
       vue: 3.5.12(typescript@5.6.2)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `@mineadmin/table` dependency to improve performance and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->