### PR TITLE
refactor(PermissionService): update getEnforce method to use dependency injection- Remove private readonly Enforcer property- Update getEnforce to use make(Enforcer::class) - Simplify constructor by removing Enforcer parameter

### DIFF
--- a/app/Service/PermissionService.php
+++ b/app/Service/PermissionService.php
@@ -16,12 +16,9 @@ use Casbin\Enforcer;
 
 final class PermissionService
 {
-    public function __construct(
-        private readonly Enforcer $enforcer
-    ) {}
 
     public function getEnforce(): Enforcer
     {
-        return $this->enforcer;
+        return make(Enforcer::class);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `PermissionService` to utilize a factory method for obtaining the `Enforcer` instance, enhancing flexibility in how permissions are managed. 

- **Bug Fixes**
	- Resolved potential issues related to dependency injection by removing the constructor and simplifying the `getEnforce` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->