### PR TITLE
refactor(delete): change delete method return type and behavior

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         php-version: [ '8.3', '8.2', '8.1' ]
-        sw-version: [ 'v5.0.3', 'v5.1.3', 'master' ]
+        sw-version: [ 'v5.0.3', 'v5.1.5', 'master' ]
         exclude:
           - php-version: '8.3'
             sw-version: 'v5.0.3'

--- a/app/Http/Admin/Controller/Permission/MenuController.php
+++ b/app/Http/Admin/Controller/Permission/MenuController.php
@@ -112,7 +112,7 @@ final class MenuController extends AbstractController
     #[Permission(code: 'permission:menu:delete')]
     public function delete(): Result
     {
-        $this->service->deleteById($this->getRequestData(), false);
+        $this->service->deleteById($this->getRequestData());
         return $this->success();
     }
 }

--- a/app/Http/Admin/Controller/Permission/RoleController.php
+++ b/app/Http/Admin/Controller/Permission/RoleController.php
@@ -120,7 +120,7 @@ final class RoleController extends AbstractController
     #[Permission(code: 'permission:role:delete')]
     public function delete(): Result
     {
-        $this->service->deleteById($this->getRequestData(), false);
+        $this->service->deleteById($this->getRequestData());
         return $this->success();
     }
 

--- a/app/Http/Admin/Controller/Permission/UserController.php
+++ b/app/Http/Admin/Controller/Permission/UserController.php
@@ -112,7 +112,7 @@ final class UserController extends AbstractController
     #[ResultResponse(new Result())]
     public function create(UserRequest $request): Result
     {
-        $this->userService->create(array_merge($request->validated(),[
+        $this->userService->create(array_merge($request->validated(), [
             'created_by' => $this->currentUser->id(),
         ]));
         return $this->success();
@@ -145,7 +145,7 @@ final class UserController extends AbstractController
     #[ResultResponse(new Result())]
     public function save(int $userId, UserRequest $request): Result
     {
-        $this->userService->updateById($userId, array_merge($request->validated(),[
+        $this->userService->updateById($userId, array_merge($request->validated(), [
             'updated_by' => $this->currentUser->id(),
         ]));
         return $this->success();

--- a/app/Http/Admin/Controller/Permission/UserController.php
+++ b/app/Http/Admin/Controller/Permission/UserController.php
@@ -127,7 +127,7 @@ final class UserController extends AbstractController
     #[ResultResponse(new Result())]
     public function delete(): Result
     {
-        $this->userService->deleteById($this->getRequestData(), false);
+        $this->userService->deleteById($this->getRequestData());
         return $this->success();
     }
 

--- a/app/Http/Admin/Controller/Permission/UserController.php
+++ b/app/Http/Admin/Controller/Permission/UserController.php
@@ -112,7 +112,9 @@ final class UserController extends AbstractController
     #[ResultResponse(new Result())]
     public function create(UserRequest $request): Result
     {
-        $this->userService->create($request->validated());
+        $this->userService->create(array_merge($request->validated(),[
+            'created_by' => $this->currentUser->id(),
+        ]));
         return $this->success();
     }
 
@@ -143,7 +145,9 @@ final class UserController extends AbstractController
     #[ResultResponse(new Result())]
     public function save(int $userId, UserRequest $request): Result
     {
-        $this->userService->updateById($userId, $request->validated());
+        $this->userService->updateById($userId, array_merge($request->validated(),[
+            'updated_by' => $this->currentUser->id(),
+        ]));
         return $this->success();
     }
 

--- a/app/Http/Admin/Controller/PermissionController.php
+++ b/app/Http/Admin/Controller/PermissionController.php
@@ -58,11 +58,13 @@ final class PermissionController extends AbstractController
     public function menus(): Result
     {
         return $this->success(
-            data: $this->currentUser->isSuperAdmin() ? $this->repository->list([
-                'status' => Status::Normal,
-                'children' => true,
-                'parent_id' => 0,
-            ]) : $this->currentUser->permissions()
+            data: $this->currentUser->isSuperAdmin()
+                ? $this->repository->list([
+                    'status' => Status::Normal,
+                    'children' => true,
+                    'parent_id' => 0,
+                ])
+                : $this->currentUser->filterCurrentUser()
         );
     }
 
@@ -82,7 +84,7 @@ final class PermissionController extends AbstractController
         return $this->success(
             data: $this->currentUser->isSuperAdmin()
                 ? $this->roleRepository->list(['status' => Status::Normal])
-                : $this->currentUser->roles()
+                : $this->currentUser->user()->getRoles(['name', 'code', 'remark'])
         );
     }
 

--- a/app/Http/Admin/Middleware/PermissionMiddleware.php
+++ b/app/Http/Admin/Middleware/PermissionMiddleware.php
@@ -68,7 +68,7 @@ final class PermissionMiddleware implements MiddlewareInterface
         $operation = $permission->getOperation();
         $codes = $permission->getCode();
         foreach ($codes as $code) {
-            $isMenu = $this->currentUser->hasMenu($code);
+            $isMenu = $this->currentUser->user()->hasPermission($code);
             if ($operation === Permission::OPERATION_AND && ! $isMenu) {
                 throw new BusinessException(code: ResultCode::FORBIDDEN);
             }

--- a/app/Http/Admin/Request/Permission/BatchGrantPermissionsForRoleRequest.php
+++ b/app/Http/Admin/Request/Permission/BatchGrantPermissionsForRoleRequest.php
@@ -32,7 +32,7 @@ class BatchGrantPermissionsForRoleRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'permissions' => 'required|array',
+            'permissions' => 'sometimes|array',
             'permissions.*' => 'string|exists:menu,name',
         ];
     }

--- a/app/Http/CurrentUser.php
+++ b/app/Http/CurrentUser.php
@@ -12,12 +12,12 @@ declare(strict_types=1);
 
 namespace App\Http;
 
-use App\Model\Enums\User\Type;
 use App\Model\Permission\Menu;
 use App\Model\Permission\Role;
 use App\Model\Permission\User;
 use App\Service\PassportService;
 use App\Service\Permission\UserService;
+use Hyperf\Collection\Arr;
 use Hyperf\Collection\Collection;
 use Lcobucci\JWT\Token\RegisteredClaims;
 use Mine\Jwt\Traits\RequestScopedTokenTrait;
@@ -46,36 +46,37 @@ final class CurrentUser
         return (int) $this->getToken()->claims()->get(RegisteredClaims::ID);
     }
 
-    /**
-     * @return Collection<int,Menu>
-     */
-    public function permissions(): Collection
-    {
-        // @phpstan-ignore-next-line
-        return $this->user()->getPermissions();
-    }
-
-    /**
-     * @return Collection<int, Role>
-     */
-    public function roles(): Collection
-    {
-        // @phpstan-ignore-next-line
-        return $this->user()->getRoles()->map(static fn (Role $role) => $role->only(['name', 'code', 'remark']));
-    }
-
-    public function hasMenu(string $menuCode): bool
-    {
-        return $this->user()->roles()->whereHas('menus', static fn ($query) => $query->where('name', $menuCode))->exists();
-    }
-
-    public function isSystem(): bool
-    {
-        return $this->user()->user_type === Type::SYSTEM;
-    }
-
     public function isSuperAdmin(): bool
     {
         return $this->user()->isSuperAdmin();
+    }
+
+    public function filterCurrentUser(?array $menuTreeList = null, ?array $permissions = null): array
+    {
+        $permissions = $permissions ?? $this->user()->getPermissions()->pluck('name')->toArray();
+        $menuTreeList = $menuTreeList ?? $this->globalMenuTreeList()->toArray();
+
+        return Arr::where(
+            array_map(
+                fn(array $menu) => $this->filterMenu($menu, $permissions),
+                $menuTreeList
+            ),
+            fn(array $menu) => in_array($menu['name'], $permissions, true)
+        );
+    }
+
+    private function filterMenu(array $menu, array $permissions): array
+    {
+        if (!empty($menu['children'])) {
+            $menu['children'] = $this->filterCurrentUser($menu['children'], $permissions);
+        }
+        return $menu;
+    }
+
+    public function globalMenuTreeList(): Collection
+    {
+        return $this->user()->roles()->get()->map(static function (Role $role) {
+            return $role->menus()->where('parent_id', 0)->with('children')->get();
+        })->flatten();
     }
 }

--- a/app/Model/Permission/Menu.php
+++ b/app/Model/Permission/Menu.php
@@ -18,7 +18,6 @@ use Carbon\Carbon;
 use Hyperf\Database\Model\Collection;
 use Hyperf\Database\Model\Relations\BelongsToMany;
 use Hyperf\DbConnection\Model\Model as MineModel;
-use Mine\Casbin\Rule\Rule;
 
 /**
  * @property int $id 主键
@@ -36,6 +35,7 @@ use Mine\Casbin\Rule\Rule;
  * @property Carbon $updated_at 更新时间]
  * @property string $remark 备注
  * @property Collection|Role[] $roles
+ * @property Collection|Menu[] $children
  */
 final class Menu extends MineModel
 {
@@ -71,17 +71,12 @@ final class Menu extends MineModel
      */
     public function roles(): BelongsToMany
     {
-        // @phpstan-ignore-next-line
         return $this->belongsToMany(
             Role::class,
-            // @phpstan-ignore-next-line
-            Rule::getModel()->getTable(),
-            'v1',
-            'v0',
-            'code',
-            'name'
-            // @phpstan-ignore-next-line
-        )->where(Rule::getModel()->getTable() . '.ptype', 'p');
+            'role_belongs_menu',
+            'menu_id',
+            'role_id'
+        );
     }
 
     public function children()

--- a/app/Model/Permission/Role.php
+++ b/app/Model/Permission/Role.php
@@ -64,7 +64,6 @@ final class Role extends MineModel
      */
     public function menus(): BelongsToMany
     {
-        // @phpstan-ignore-next-line
         return $this->belongsToMany(
             Menu::class,
             'role_belongs_menu',

--- a/app/Model/Permission/User.php
+++ b/app/Model/Permission/User.php
@@ -17,6 +17,7 @@ use App\Model\Enums\User\Type;
 use Carbon\Carbon;
 use Hyperf\Collection\Collection;
 use Hyperf\Database\Model\Events\Creating;
+use Hyperf\Database\Model\Events\Deleted;
 use Hyperf\Database\Model\Relations\BelongsToMany;
 use Hyperf\DbConnection\Model\Model;
 
@@ -81,6 +82,11 @@ final class User extends Model
             // @phpstan-ignore-next-line
             'user_belongs_role',
         );
+    }
+
+    public function deleted(Deleted $event)
+    {
+        $this->roles()->detach();
     }
 
     public function setPasswordAttribute($value): void

--- a/app/Model/Permission/User.php
+++ b/app/Model/Permission/User.php
@@ -116,18 +116,25 @@ final class User extends Model
         return $this->roles()->where('code', 'SuperAdmin')->exists();
     }
 
-    public function getRoles(): Collection
+    public function getRoles(array $fields): Collection
     {
         return $this->roles()
             ->where('status', Status::Normal)
+//            ->select(['id', ...$fields])
+            ->select($fields)
             ->get();
     }
 
+    /**
+     * @return Collection<int, Menu>
+     */
     public function getPermissions(): Collection
     {
-        // @phpstan-ignore-next-line
-        return $this->roles()->get()->map(static function (Role $role) {
-            return $role->menus()->where('parent_id', 0)->with('children')->get();
-        })->flatten();
+        return $this->roles()->with('menus')->get()->pluck('menus')->flatten();
+    }
+
+    public function hasPermission(string $permission): bool
+    {
+        return $this->roles()->whereRelation('menus', 'name', $permission)->exists();
     }
 }

--- a/app/Repository/IRepository.php
+++ b/app/Repository/IRepository.php
@@ -106,10 +106,10 @@ abstract class IRepository
         }, $this->model, $id, $data);
     }
 
-    public function deleteById(mixed $id): bool
+    public function deleteById(mixed $id): int
     {
         // @phpstan-ignore-next-line
-        return (bool) $this->model->whereKey($id)->delete();
+        return $this->model::destroy($id);
     }
 
     public function forceDeleteById(mixed $id): bool

--- a/app/Service/IService.php
+++ b/app/Service/IService.php
@@ -63,9 +63,9 @@ abstract class IService
         return $this->repository->updateById($id, $data);
     }
 
-    public function deleteById(mixed $id, bool $force = true): bool
+    public function deleteById(mixed $id): int
     {
-        return $force ? $this->repository->forceDeleteById($id) : $this->repository->deleteById($id);
+        return $this->repository->deleteById($id);
     }
 
     /**

--- a/app/Service/Permission/RoleService.php
+++ b/app/Service/Permission/RoleService.php
@@ -37,6 +37,7 @@ final class RoleService extends IService
     public function batchGrantPermissionsForRole(int $id, array $permissionsCode): void
     {
         if (\count($permissionsCode) === 0) {
+            // @phpstan-ignore-next-line
             $this->repository->findById($id)->menus()->detach();
             return;
         }

--- a/app/Service/Permission/RoleService.php
+++ b/app/Service/Permission/RoleService.php
@@ -36,6 +36,10 @@ final class RoleService extends IService
 
     public function batchGrantPermissionsForRole(int $id, array $permissionsCode): void
     {
+        if (\count($permissionsCode) === 0) {
+            $this->repository->findById($id)->menus()->detach();
+            return;
+        }
         // @phpstan-ignore-next-line
         $this->repository->findById($id)
             ->menus()

--- a/tests/Feature/Admin/Permission/RoleControllerTest.php
+++ b/tests/Feature/Admin/Permission/RoleControllerTest.php
@@ -196,9 +196,9 @@ final class RoleControllerTest extends ControllerCase
         $token = $this->token;
         $uri = '/admin/role/' . $role->id . '/permissions';
         $result = $this->put($uri);
-        self::assertSame($result['code'], ResultCode::UNPROCESSABLE_ENTITY->value);
+        self::assertSame($result['code'], ResultCode::UNAUTHORIZED->value);
         $result = $this->put($uri, [], ['Authorization' => 'Bearer ' . $token]);
-        self::assertSame($result['code'], ResultCode::UNPROCESSABLE_ENTITY->value);
+        self::assertSame($result['code'], ResultCode::FORBIDDEN->value);
         $result = $this->put($uri, ['permissions' => $names], ['Authorization' => 'Bearer ' . $token]);
         self::assertSame($result['code'], ResultCode::FORBIDDEN->value);
         $this->forAddPermission('permission:role:setMenu');

--- a/web/.env.development
+++ b/web/.env.development
@@ -5,7 +5,7 @@ VITE_APP_PORT = 2888
 # 应用根路径
 VITE_APP_ROOT_BASE = /
 # 接口请求地址，会设置到 axios 的 baseURL 参数上
-VITE_APP_API_BASEURL = http://127.0.0.1:9501
+VITE_APP_API_BASEURL = http://172.18.0.3:9501
 # 路由模式: history 和 hash 两种，默认hash，带#号那种
 VITE_APP_ROUTE_MODE = hash
 

--- a/web/.env.development
+++ b/web/.env.development
@@ -5,7 +5,7 @@ VITE_APP_PORT = 2888
 # 应用根路径
 VITE_APP_ROOT_BASE = /
 # 接口请求地址，会设置到 axios 的 baseURL 参数上
-VITE_APP_API_BASEURL = http://172.18.0.3:9501
+VITE_APP_API_BASEURL = http://127.0.0.1:9501
 # 路由模式: history 和 hash 两种，默认hash，带#号那种
 VITE_APP_ROUTE_MODE = hash
 


### PR DESCRIPTION
- Update IRepository::deleteById to return int instead of bool
- Update IService::deleteById to return int and remove force parameter
- Modify User model to detach roles after deletion
- Update related files to reflect these changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to clean up user roles upon deletion.
	- Added functionality to track the creator and updater of users during creation and modification.
	- Implemented a check for empty permissions in role permission management.

- **Changes**
	- Updated the Swoole version in the testing environment.
	- Simplified the deletion process in multiple controllers by removing redundant parameters.
	- Enhanced feedback for deletion operations by changing return types to indicate the number of records deleted.
	- Modified validation rules to make permissions optional in certain requests.
	- Improved user permission handling and menu filtering logic.

These updates enhance functionality and streamline user interactions with the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->