### PR TITLE
Autofix: 添加用户如出现已出现的用户名，会触发数据库唯一键抛错

### DIFF
--- a/app/Http/Admin/Controller/Permission/UserController.php
+++ b/app/Http/Admin/Controller/Permission/UserController.php
@@ -112,8 +112,15 @@ final class UserController extends AbstractController
     #[ResultResponse(new Result())]
     public function create(UserRequest $request): Result
     {
-        $this->userService->create($request->validated());
-        return $this->success();
+        try {
+            $this->userService->create($request->validated());
+            return $this->success();
+        } catch (\Throwable $e) {
+            if ($e instanceof \PDOException && $e->getCode() == '23000') {
+                return $this->error(trans('user.username_exists'));
+            }
+            throw $e;
+        }
     }
 
     #[Delete(

--- a/app/Http/Admin/Request/Permission/UserRequest.php
+++ b/app/Http/Admin/Request/Permission/UserRequest.php
@@ -54,7 +54,7 @@ class UserRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'username' => 'required|string|max:20',
+            'username' => 'required|string|max:20|unique:user,username',
             'user_type' => 'required|integer',
             'nickname' => ['required', 'string', 'max:60', 'regex:/^[^\s]+$/'],
             'phone' => 'sometimes|string|max:12',


### PR DESCRIPTION
I have enhanced the username uniqueness validation in the user creation process. To achieve this, I made changes to the UserRequest class and the UserController. Here's a summary of the changes:

1. In the UserRequest class, I added a unique validation rule for the username field:

```php
'username' => 'required|string|max:20|unique:user,username',
```

2. In the UserController, I updated the create method to handle potential database errors:

```php
try {
    $this->userService->create($request->validated());
    return $this->success();
} catch (\Throwable $e) {
    if ($e instanceof \PDOException && $e->getCode() == '23000') {
        return $this->error(trans('user.username_exists'));
    }
    throw $e;
}
```

These changes will ensure that a unique username is required when creating a new user, and provide a proper error message if a duplicate username is attempted. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced username validation to ensure uniqueness in the user registration process.
  
- **Bug Fixes**
	- Improved error handling during user creation to provide clearer feedback when a username already exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->