### PR TITLE
chore(front): 退出清除所有tab，ma-dialog新增操作快捷键，ma-tree增加 buttons插槽

### DIFF
--- a/web/src/components/ma-dialog/index.vue
+++ b/web/src/components/ma-dialog/index.vue
@@ -9,7 +9,7 @@
 -->
 <script setup lang="ts">
 import type { Ref } from 'vue'
-import { useResizeObserver } from '@vueuse/core'
+import {useMagicKeys, useResizeObserver} from '@vueuse/core'
 import { ElDialog } from 'element-plus'
 
 defineOptions({ name: 'MaDialog' })
@@ -32,9 +32,24 @@ function okLoadingState(state: boolean) {
   okLoading.value = state
 }
 
+const attrs = useAttrs()
 const t = useTrans().globalTrans
 
 const isOpen = defineModel<boolean>({ default: false })
+
+function ok() {
+  emit('ok', { okLoadingState, attrs })
+}
+
+const { current } = useMagicKeys()
+const keys = computed(() => Array.from(current))
+
+watch(() => keys.value, async () => {
+  const [one, two] = keys.value
+  if (isOpen.value && one === 'control' && two === 'enter') {
+    ok()
+  }
+})
 
 onMounted(() => {
   useResizeObserver(document.body, (entries) => {
@@ -92,8 +107,8 @@ onMounted(() => {
     </template>
     <template #footer>
       <slot v-if="$attrs.footer" name="footer">
-        <el-button type="primary" :loading="okLoading" @click="() => emit('ok', { okLoadingState, $attrs })">
-          {{ t('crud.ok') }}
+        <el-button type="primary" :loading="okLoading" @click="ok">
+          {{ `${t('crud.ok')} Ctrl + Enter` }}
         </el-button>
         <el-button
           @click="(e) => {
@@ -101,7 +116,7 @@ onMounted(() => {
             isOpen = false
           }"
         >
-          {{ t('crud.cancel') }}
+          {{ `${t('crud.cancel')} Esc` }}
         </el-button>
       </slot>
     </template>

--- a/web/src/components/ma-tree/index.vue
+++ b/web/src/components/ma-tree/index.vue
@@ -130,6 +130,7 @@ defineExpose({
         <el-button @click="toggle(false)">
           {{ t('fold') }}
         </el-button>
+        <slot name="buttons" />
       </el-button-group>
     </div>
   </div>

--- a/web/src/store/modules/useUserStore.ts
+++ b/web/src/store/modules/useUserStore.ts
@@ -145,6 +145,7 @@ const useUserStore = defineStore(
 
     async function logout(redirect = router.currentRoute.value.fullPath) {
       await usePluginStore().callHooks('logout')
+      useTabStore().clearTab()
       clearInfo()
       await router.push({
         name: 'login',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `ma-dialog` component with keyboard shortcuts for 'ok' (Ctrl + Enter) and 'cancel' (Esc) actions.
	- Introduced a new slot in the `MaTree` component for custom button integration.

- **Bug Fixes**
	- Improved logout process in the user store to clear open tabs before redirecting to the login page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->