### PR TITLE
chore(ma-pro-table): 更新ma-pro-table到1.0.27版，pnpm-lock加入忽略列表

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -5,4 +5,5 @@ dist-ssr
 *.local
 .eslintcache
 .stylelintcache
+pnpm-lock.yaml
 .idea*

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
     "@imengyu/vue3-context-menu": "^1.4.2",
     "@mineadmin/echarts": "^1.0.1",
     "@mineadmin/form": "^1.0.21",
-    "@mineadmin/pro-table": "^1.0.25",
+    "@mineadmin/pro-table": "^1.0.27",
     "@mineadmin/search": "^1.0.21",
     "@mineadmin/table": "^1.0.29",
     "@vueuse/core": "^11.1.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `mineadmin-ui` package to `3.0.0`.
	- Updated the `@mineadmin/pro-table` dependency to version `^1.0.27`.
	- Added `pnpm-lock.yaml` to the `.gitignore` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->