### PR TITLE
feat(dict-component): 字典组件props增加data参数，可直接传入字典数据集合

### DIFF
--- a/web/src/components/ma-dict-picker/ma-dict-checkbox.vue
+++ b/web/src/components/ma-dict-picker/ma-dict-checkbox.vue
@@ -15,11 +15,14 @@ defineOptions({ name: 'MaDictCheckbox' })
 
 const {
   dictName = '',
+  data = [],
   renderMode = 'normal',
   transScope = 'global',
 } = defineProps<{
   // 字典名称
-  dictName: string
+  dictName?: string
+  // 字典数据
+  data?: Dictionary[]
   // 渲染模式：`normal: el-checkbox` | `button: el-checkbox-button`
   renderMode?: 'normal' | 'button'
   // 翻译范围
@@ -27,7 +30,7 @@ const {
 }>()
 const dictStore = useDictStore()
 const dictionaryData = computed<Dictionary[] | null>(() => {
-  return dictStore.find(dictName)
+  return dictName === '' ? data : dictStore.find(dictName)
 })
 
 const i18n = useTrans() as TransType

--- a/web/src/components/ma-dict-picker/ma-dict-radio.vue
+++ b/web/src/components/ma-dict-picker/ma-dict-radio.vue
@@ -15,11 +15,14 @@ defineOptions({ name: 'MaDictRadio' })
 
 const {
   dictName = '',
+  data = [],
   renderMode = 'normal',
   transScope = 'global',
 } = defineProps<{
   // 字典名称
-  dictName: string
+  dictName?: string
+  // 字典数据
+  data?: Dictionary[]
   // 渲染模式：`normal: el-radio` | `button: el-radio-button`
   renderMode?: 'normal' | 'button'
   // 翻译范围
@@ -27,7 +30,7 @@ const {
 }>()
 const dictStore = useDictStore()
 const dictionaryData = computed<Dictionary[] | null>(() => {
-  return dictStore.find(dictName)
+  return dictName === '' ? data : dictStore.find(dictName)
 })
 
 const i18n = useTrans() as TransType

--- a/web/src/components/ma-dict-picker/ma-dict-select.vue
+++ b/web/src/components/ma-dict-picker/ma-dict-select.vue
@@ -15,17 +15,20 @@ defineOptions({ name: 'MaDictSelect' })
 
 const {
   dictName = '',
+  data = [],
   transScope = 'global',
 } = defineProps<{
   // 字典名称
-  dictName: string
+  dictName?: string
+  // 字典数据
+  data?: Dictionary[]
   // 翻译范围
   transScope?: 'global' | 'local'
 }>()
 
 const dictStore = useDictStore()
 const dictionaryData = computed<Dictionary[] | null>(() => {
-  return dictStore.find(dictName)
+  return dictName === '' ? data : dictStore.find(dictName)
 })
 
 const i18n = useTrans() as TransType


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `data` property in dictionary components to accept external dictionary data.
	- Updated the `dictName` property to be optional, enhancing flexibility in component usage.
	- Improved logic for handling dictionary data, allowing components to utilize provided data when no dictionary name is specified.

These changes enhance the components' capability to handle both internal and external dictionary data more effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->