### PR TITLE
fix：修增菜单含三级或以上的情况下只有一级菜单有选中样式

### DIFF
--- a/web/src/layouts/components/menu/item.tsx
+++ b/web/src/layouts/components/menu/item.tsx
@@ -33,7 +33,7 @@ export default defineComponent({
       if (!route?.meta?.breadcrumb || !route.meta.breadcrumb.length) {
         return false
       }
-      return route.meta.breadcrumb[0].name === item.name
+      return route.meta.breadcrumb.some(breadcrumb => breadcrumb.name === item.name)
     })
 
     const isItemActive = computed(() => {


### PR DESCRIPTION
修正前：
<img width="725" alt="image" src="https://github.com/user-attachments/assets/c919522e-435a-4e98-9a6b-71b4a370d99e">

修正后：
<img width="731" alt="image" src="https://github.com/user-attachments/assets/7bf1dbf4-b058-46df-ba3e-5791e11f3678">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the logic for determining if a parent menu item is active, enhancing flexibility and accuracy.

- **Refactor**
	- Adjusted the active state determination method for parent items without altering component structure or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->