### PR TITLE
fix(front-permission): 修复前端权限检查时如果值为空对象时：`{}`，进入判断条件，导致显示无权限

### DIFF
--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -15,6 +15,7 @@ import '@/assets/styles/nprogress.scss'
 import hasAuth from '@/utils/permission/hasAuth.ts'
 import hasRole from '@/utils/permission/hasRole.ts'
 import hasUser from '@/utils/permission/hasUser.ts'
+import { isEmpty } from 'radash'
 
 const { isLoading } = useNProgress()
 
@@ -53,16 +54,19 @@ router.afterEach(async (to) => {
   isLoading.value = false
   const keepAliveStore = useKeepAliveStore()
 
-  if (to.meta.auth && !hasAuth(to.meta.auth as string[])) {
+  if (!isEmpty(to.meta.auth) && !hasAuth(to.meta.auth as string[])) {
     await router.push({ path: '/403' })
+    return
   }
 
-  if (to.meta.role && !hasRole(to.meta.role as string[])) {
+  if (!isEmpty(to.meta.role) && !hasRole(to.meta.role as string[])) {
     await router.push({ path: '/403' })
+    return
   }
 
-  if (to.meta.user && !hasUser(to.meta.user as string[])) {
+  if (!isEmpty(to.meta.user) && !hasUser(to.meta.user as string[])) {
     await router.push({ path: '/403' })
+    return
   }
 
   if (to.meta.cache) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced routing logic with improved checks for user authentication and roles.
	- Added redirection to a 403 error page for empty metadata conditions.

- **Bug Fixes**
	- Prevented unnecessary permission-checking function calls for empty metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->