### PR TITLE
fix(pro-table): 修复单元格插件注册后调用无效的问题

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
     "@imengyu/vue3-context-menu": "^1.4.2",
     "@mineadmin/echarts": "^1.0.1",
     "@mineadmin/form": "^1.0.21",
-    "@mineadmin/pro-table": "^1.0.37",
+    "@mineadmin/pro-table": "^1.0.41",
     "@mineadmin/search": "^1.0.25",
     "@mineadmin/table": "^1.0.29",
     "@vueuse/core": "^11.1.0",

--- a/web/src/plugins/mine-admin/demo/index.ts
+++ b/web/src/plugins/mine-admin/demo/index.ts
@@ -11,6 +11,7 @@ import type { Router } from 'vue-router'
 import { useProTableRenderPlugin } from '@mineadmin/pro-table'
 import type { MineToolbarExpose, Plugin } from '#/global'
 import Message from 'vue-m-message'
+import { ElButton } from 'element-plus'
 
 const pluginConfig: Plugin.PluginConfig = {
   install(app) {
@@ -42,7 +43,9 @@ const pluginConfig: Plugin.PluginConfig = {
       const { addPlugin } = useProTableRenderPlugin()
       addPlugin({
         name: 'test',
-        render: () => '我是demo插件渲染出来的内容',
+        render: () => {
+          return h(ElButton, null, 'test')
+        },
       })
     },
     login: (formInfo) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new button component in the demo plugin, enhancing the user interface with interactive elements.
  
- **Dependency Updates**
	- Upgraded the `@mineadmin/pro-table` package to the latest version for improved functionality and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->