### PR TITLE
fix(docker-compose/dockerfile):修复docker-compose只能发布前端一个环境的问题

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,6 @@ services:
   frontend:
     build:
       context: ./web
-    environment:
-      MINE_NODE_ENV: production
+      args:
+        MINE_NODE_ENV: production
     restart: always

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -6,18 +6,14 @@ COPY . /opt/www/
 
 RUN npm install -g pnpm
 
-ARG MINE_NODE_ENV=production
-
-ENV MINE_NODE_ENV $MINE_NODE_ENV
+ARG MINE_NODE_ENV
 
 RUN echo "MINE_NODE_ENV=$MINE_NODE_ENV"
-
 
 RUN pnpm install
 RUN if [ "$MINE_NODE_ENV" = "development" ]; then pnpm build --mode development; fi && \
     if [ "$MINE_NODE_ENV" = "production" ]; then pnpm build --mode production; fi
 
-RUN pnpm build --mode production
 
 FROM nginx:alpine AS production
 


### PR DESCRIPTION
fix(docker-compose/dockerfile):修复docker-compose只能发布前端一个环境的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the frontend service configuration in the Docker Compose file.
	- Changed the base image in the Dockerfile to a newer version.
	- Streamlined the build process in the Dockerfile while retaining conditional logic for builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->