### PR TITLE
fix(docker-compose/dockerfile):修复docker-compose只能发布前端一个环境的问题

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,6 @@ services:
   frontend:
     build:
       context: ./web
-    environment:
-      MINE_NODE_ENV: production
+      args:
+        MINE_NODE_ENV: production
     restart: always

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -8,16 +8,12 @@ RUN npm install -g pnpm
 
 ARG MINE_NODE_ENV=production
 
-ENV MINE_NODE_ENV $MINE_NODE_ENV
-
 RUN echo "MINE_NODE_ENV=$MINE_NODE_ENV"
-
 
 RUN pnpm install
 RUN if [ "$MINE_NODE_ENV" = "development" ]; then pnpm build --mode development; fi && \
     if [ "$MINE_NODE_ENV" = "production" ]; then pnpm build --mode production; fi
 
-RUN pnpm build --mode production
 
 FROM nginx:alpine AS production
 


### PR DESCRIPTION
fix(docker-compose/dockerfile):修复docker-compose只能发布前端一个环境的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the base image for the frontend service to a newer version.
- **Bug Fixes**
	- Improved the handling of the `MINE_NODE_ENV` environment variable during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->