### PR TITLE
feat(ma-pro-table & ma-remote-select) :

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
     "@imengyu/vue3-context-menu": "^1.4.2",
     "@mineadmin/echarts": "^1.0.5",
     "@mineadmin/form": "^1.0.21",
-    "@mineadmin/pro-table": "^1.0.53",
+    "@mineadmin/pro-table": "^1.0.55",
     "@mineadmin/search": "^1.0.25",
     "@mineadmin/table": "^1.0.29",
     "@vueuse/core": "^11.1.0",

--- a/web/src/components/ma-remote-select/index.vue
+++ b/web/src/components/ma-remote-select/index.vue
@@ -17,6 +17,7 @@ const props = defineProps<{
   api?: <T>(...args: T[]) => Promise<T>
   url?: string
   axiosConfig?: {
+    autoRequest: boolean
     method?: string
     params?: Record<string, any>
     data?: Record<string, any>
@@ -26,40 +27,61 @@ const props = defineProps<{
   dataHandle?: (response: any) => any[]
 }>()
 
-const msg = useMessage()
+const emit = defineEmits<{
+  (event: 'select-item', value: Record<string, any>): void
+  (event: 'change', value: any): void
+}>()
 
-// const emit = defineEmits<{
-//   (event: 'select', value: Record<string, any>): void
-// }>()
-// function handleChange(val: any) {
-//
-// }
+const elSelectV2Ref = ref<any>()
+const msg = useMessage()
 const model = defineModel<any>()
 const options = ref<any[]>([])
 
-if (props?.api && typeof props.api === 'function') {
-  props.api().then((res: any) => {
-    options.value = props?.dataHandle?.(res) ?? res.data
-  }).catch((err) => {
-    msg.error(err)
-  })
+function handleChange(value: any) {
+  emit('change', value)
+  const key = elSelectV2Ref.value.valueKey
+  emit('select-item', options.value.find(item => item[key] === value) ?? null)
 }
-else if (props?.url) {
-  const method = useHttp()[props?.axiosConfig?.method ?? 'get']
-  method(props?.url, props?.axiosConfig).then((res: any) => {
-    options.value = props?.dataHandle?.(res) ?? res.data
-  }).catch((err: any) => {
-    msg.error(err)
-  })
+
+function request() {
+  if (props?.api && typeof props.api === 'function') {
+    props.api().then((res: any) => {
+      options.value = props?.dataHandle?.(res) ?? res.data
+    }).catch((err) => {
+      msg.error(err)
+    })
+  }
+  else if (props?.url) {
+    const method = useHttp()[props?.axiosConfig?.method ?? 'get']
+    method(props?.url, props?.axiosConfig).then((res: any) => {
+      options.value = props?.dataHandle?.(res) ?? res.data
+    }).catch((err: any) => {
+      msg.error(err)
+    })
+  }
+  else {
+    msg.error('MaRemoteSelect 组件未指定 api 或 url ')
+    console.error('[ma-remote-select]：api() or url error')
+  }
 }
-else {
-  msg.error('MaRemoteSelect 组件未指定 api 或 url ')
-  console.error('[ma-remote-select]：api() or url error')
-}
+
+(props?.axiosConfig?.autoRequest ?? true) && request()
+
+defineExpose({
+  refresh: () => request(),
+  selectRef: elSelectV2Ref,
+})
 </script>
 
 <template>
-  <ElSelectV2 v-bind="$attrs" v-model="model" :options="options" clearable>
+  <ElSelectV2
+    ref="elSelectV2Ref"
+    v-bind="$attrs"
+    v-model="model"
+    :options="options"
+    clearable
+    @change="handleChange"
+  >
     <template v-for="slot in Object.keys($slots)" #[slot]>
       <slot :name="slot" />
     </template>

--- a/web/types/auto-imports.d.ts
+++ b/web/types/auto-imports.d.ts
@@ -97,6 +97,6 @@ declare global {
 // for type re-export
 declare global {
   // @ts-ignore
-  export type { Component, ComponentPublicInstance, ComputedRef, DirectiveBinding, ExtractDefaultPropTypes, ExtractPropTypes, ExtractPublicPropTypes, InjectionKey, PropType, Ref, MaybeRef, MaybeRefOrGetter, VNode, WritableComputedRef } from 'vue'
+  export type { Component, ComponentPublicInstance, ComputedRef, ExtractDefaultPropTypes, ExtractPropTypes, ExtractPublicPropTypes, InjectionKey, PropType, Ref, VNode, WritableComputedRef } from 'vue'
   import('vue')
 }


### PR DESCRIPTION
- ma-pro-table更新到1.0.55版本
- ma-remote-select 覆盖原组件的change事件
- ma-remote-select 增加select-item事件，可获取所选项整个数据项
- ma-remote-select 增加允许是否自动请求
- ma-remote-select 增加 expose 暴露 el-select-v2 的组件属性 和 组件自定义的 refresh 方法

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `ma-remote-select` component with an `autoRequest` property for conditional API requests.
	- New events `select-item` and `change` emitted during item selection.
	- Exposed `refresh` method and `selectRef` reference for external access.

- **Bug Fixes**
	- Updated dependency version for `@mineadmin/pro-table` to ensure compatibility.

- **Documentation**
	- Adjusted TypeScript declarations for auto-imports, removing obsolete types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->