### PR TITLE
fix(ma-remote-select): 修复 api 参数未传入 axiosConfig 配置项

### DIFF
--- a/web/src/components/ma-remote-select/index.vue
+++ b/web/src/components/ma-remote-select/index.vue
@@ -45,7 +45,7 @@ function handleChange(value: any) {
 
 function request() {
   if (props?.api && typeof props.api === 'function') {
-    props.api().then((res: any) => {
+    props.api(props.axiosConfig).then((res: any) => {
       options.value = props?.dataHandle?.(res) ?? res.data
     }).catch((err) => {
       msg.error(err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 更新了 `MaRemoteSelect` 组件的 API 调用方式，允许直接使用 Axios 配置对象。
- **错误修复**
	- 保持了错误处理逻辑不变，确保错误信息通过 `msg.error` 方法正常发出。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->