### PR TITLE
fix(ma-search): 升级ma-search到1.0.27版本

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,7 @@
     "@mineadmin/echarts": "^1.0.5",
     "@mineadmin/form": "^1.0.21",
     "@mineadmin/pro-table": "^1.0.55",
-    "@mineadmin/search": "^1.0.25",
+    "@mineadmin/search": "^1.0.27",
     "@mineadmin/table": "^1.0.29",
     "@vueuse/core": "^11.1.0",
     "@vueuse/integrations": "^11.1.0",


### PR DESCRIPTION
- 由于 `show` 属性被组件独占，导致无法隐藏某个配置项，增加 `hide` 属性

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **更新内容**
	- 更新了 `@mineadmin/search` 依赖的版本，从 `^1.0.25` 升级到 `^1.0.27`。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->