### PR TITLE
连续按两次 Alt 键，快捷键会失灵

### DIFF
--- a/web/src/layouts/components/bars/tabbar/index.tsx
+++ b/web/src/layouts/components/bars/tabbar/index.tsx
@@ -126,7 +126,14 @@ export default defineComponent({
       }
     }
 
-    const { current } = useMagicKeys()
+    const { current } = useMagicKeys({
+      passive: false,
+      onEventFired(e: KeyboardEvent) {
+        if (e.key === 'Alt') {
+          e.preventDefault()
+        }
+      },
+    })
     const keys = computed(() => Array.from(current))
     const pressKeys = reactive<{
       oneKey: string | null


### PR DESCRIPTION
连续按两次 Alt 键快捷键会触发浏览器的Access Keys模式,导致 useMagicKeys 无法正常捕捉

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了标签栏的键盘事件处理，允许自定义快捷键，避免浏览器默认行为干扰。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->