### PR TITLE
build(deps): update mineadmin package version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,14 +56,14 @@
     "hyperf/server": "3.1.*",
     "hyperf/utils": "3.1.*",
     "hyperf/validation": "~3.1",
-    "mineadmin/access": "3.0",
-    "mineadmin/app-store": "3.0",
-    "mineadmin/auth-jwt": "3.0",
-    "mineadmin/core": "3.0",
-    "mineadmin/jwt": "3.0",
-    "mineadmin/support": "3.0",
-    "mineadmin/swagger": "3.0",
-    "mineadmin/upload": "3.0"
+    "mineadmin/access": "~3.0",
+    "mineadmin/app-store": "~3.0",
+    "mineadmin/auth-jwt": "~3.0",
+    "mineadmin/core": "~3.0",
+    "mineadmin/jwt": "~3.0",
+    "mineadmin/support": "~3.0",
+    "mineadmin/swagger": "~3.0",
+    "mineadmin/upload": "~3.0"
   },
   "require-dev": {
     "doctrine/dbal": "^3.6",


### PR DESCRIPTION
- Change mineadmin package version constraints from "3.0" to "~3.0"
- This allows for more flexible version updates within the 3.0 major version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **依赖更新**
	- 更新了多个 MineAdmin 相关依赖包的版本约束
	- 将依赖版本从精确的 `3.0` 改为更灵活的 `~3.0`
	- 允许安装兼容 3.0 的未来小版本更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->