### PR TITLE
fix(seeder): 修正菜单表按钮标识

### DIFF
--- a/app/Http/Admin/Controller/Permission/MenuController.php
+++ b/app/Http/Admin/Controller/Permission/MenuController.php
@@ -72,7 +72,7 @@ final class MenuController extends AbstractController
         content: new JsonContent(ref: MenuRequest::class, title: '创建菜单')
     )]
     #[PageResponse(instance: new Result())]
-    #[Permission(code: 'permission:menu:create')]
+    #[Permission(code: 'permission:menu:save')]
     public function create(MenuRequest $request): Result
     {
         $this->service->create(array_merge($request->validated(), [
@@ -92,7 +92,7 @@ final class MenuController extends AbstractController
         content: new JsonContent(ref: MenuRequest::class, title: '编辑菜单')
     )]
     #[PageResponse(instance: new Result())]
-    #[Permission(code: 'permission:menu:save')]
+    #[Permission(code: 'permission:menu:update')]
     public function save(int $id, MenuRequest $request): Result
     {
         $this->service->updateById($id, array_merge($request->validated(), [

--- a/databases/seeders/menu_seeder_20240926.php
+++ b/databases/seeders/menu_seeder_20240926.php
@@ -167,7 +167,7 @@ class MenuSeeder20240926 extends Seeder
                                 ]),
                             ],
                             [
-                                'name' => 'permission:menu:create',
+                                'name' => 'permission:menu:save',
                                 'meta' => new Meta([
                                     'title' => '菜单保存',
                                     'type' => 'B',
@@ -175,7 +175,7 @@ class MenuSeeder20240926 extends Seeder
                                 ]),
                             ],
                             [
-                                'name' => 'permission:menu:save',
+                                'name' => 'permission:menu:update',
                                 'meta' => new Meta([
                                     'title' => '菜单更新',
                                     'type' => 'B',

--- a/tests/Feature/Admin/Permission/MenuControllerTest.php
+++ b/tests/Feature/Admin/Permission/MenuControllerTest.php
@@ -30,7 +30,7 @@ final class MenuControllerTest extends CrudControllerCase
 
     public function testCreate(): void
     {
-        $this->caseCreate('/admin/menu', 'permission:menu:create', [
+        $this->caseCreate('/admin/menu', 'permission:menu:save', [
             'parent_id' => 0,
             'name' => Str::random(10),
             'component' => Str::random(10),
@@ -59,7 +59,7 @@ final class MenuControllerTest extends CrudControllerCase
             'meta' => $this->generatorMeta(),
             'path' => Str::random(10),
         ]);
-        $this->caseSave('/admin/menu/', $entity, 'permission:menu:save', [
+        $this->caseSave('/admin/menu/', $entity, 'permission:menu:update', [
             'name' => Str::random(10),
             'component' => Str::random(10),
             'redirect' => Str::random(10),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 更新了菜单权限操作的语义
		- 将 `permission:menu:create` 更改为 `permission:menu:save`
		- 将 `permission:menu:save` 更改为 `permission:menu:update`
- **测试**
	- 更新了测试用例中的菜单权限字符串
		- 将 `permission:menu:create` 更改为 `permission:menu:save`
		- 将 `permission:menu:save` 更改为 `permission:menu:update`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->