### PR TITLE
fix：Breadcrumb navigation display hidden menu bug

### DIFF
--- a/web/src/layouts/components/bars/breadcrumb/index.tsx
+++ b/web/src/layouts/components/bars/breadcrumb/index.tsx
@@ -81,42 +81,45 @@ export default defineComponent({
                     (_ + 1) === breadcrumbs.value.length
                       ? renderBreadcrumbs(route, _)
                       : (
-                          <m-dropdown
-                            class="min-w-[5rem] p-1"
-                            v-slots={{
-                              default: () => renderBreadcrumbs(route, _),
-                              popper: () => {
-                                if (route?.children?.length > 0) {
-                                  return (
-                                    route?.children?.map((item: MineRoute.routeRecord) => (
-                                      <m-dropdown-item
-                                        type="default"
-                                        handle={async () => {
-                                          if (checkRouteIsRedirect(item, 'redirect')) {
-                                            await router.push({ path: item?.redirect as string })
-                                          }
-                                          if (checkRouteIsRedirect(item, 'component') && item.name !== route.name) {
-                                            await router.push({ path: item.path })
-                                          }
-                                        }}
-                                        v-slots={{
-                                          'default': () => <span>{item?.meta?.i18n ? useTrans(item?.meta?.i18n) : item?.meta?.title}</span>,
-                                          'prefix-icon': () => item?.meta?.icon && <ma-svg-icon name={item?.meta?.icon} size={18} />,
-                                        }}
-                                      />
-                                    ))
-                                  )
-                                }
-                              },
-                            }}
-                          />
-                        )
+                        <m-dropdown
+                          class="min-w-[5rem] p-1"
+                          v-slots={{
+                            default: () => renderBreadcrumbs(route, _),
+                            popper: () => {
+                              if (Array.isArray(route?.children) && route.children.length > 0) {
+                                return route.children
+                                  .filter((item: MineRoute.routeRecord) => !item?.meta?.hidden)
+                                  .map((item: MineRoute.routeRecord) => (
+                                    <m-dropdown-item
+                                      type="default"
+                                      key={item.path}
+                                      handle={async () => {
+                                        if (checkRouteIsRedirect(item, 'redirect')) {
+                                          await router.push({path: item?.redirect as string})
+                                        }
+                                        if (checkRouteIsRedirect(item, 'component') && item.name !== route.name) {
+                                          await router.push({path: item.path})
+                                        }
+                                      }}
+                                      v-slots={{
+                                        'default': () =>
+                                          <span>{item?.meta?.i18n ? useTrans(item?.meta?.i18n) : item?.meta?.title}</span>,
+                                        'prefix-icon': () => item?.meta?.icon
+                                          && <ma-svg-icon name={item?.meta?.icon} size={18}/>,
+                                      }}
+                                    />
+                                  ))
+                              }
+                            },
+                          }}
+                        />
+                      )
                   }
                 </div>
               ),
             )}
           </TransitionGroup>
-        )}
+          )}
       </div>
     )
   },


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/db8a3fe4-64c4-48f0-9851-cf19e859942b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **问题修复**
	- 优化面包屑导航下拉菜单显示，现在仅展示可见的导航项，提升了导航的清晰性和一致性。
  
- **重构**
	- 改进了下拉菜单的渲染效率，确保页面切换更加流畅。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->