### PR TITLE
fix swagger render bug

### DIFF
--- a/config/autoload/swagger.php
+++ b/config/autoload/swagger.php
@@ -15,7 +15,7 @@ return [
     'enable' => true,
     'port' => 9503,
     'json_dir' => BASE_PATH . '/storage/swagger',
-    'html' => BASE_PATH . '/storage/swagger/index.html',
+    'html' => file_get_contents(BASE_PATH . '/storage/swagger/index.html'),
     'url' => '/swagger',
     'auto_generate' => true,
     'scan' => [


### PR DESCRIPTION
修复：访问127.0.0.1:9503/swagger，返回路径字符串问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - 优化了API文档配置，现在直接加载HTML内容，确保文档展示更准确稳定。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->