### PR TITLE
fix: Cache retrieval logic error does not return default value

### DIFF
--- a/web/src/hooks/useCache.ts
+++ b/web/src/hooks/useCache.ts
@@ -34,7 +34,7 @@ export default function useCache(type: CacheType = 'localStorage') {
    * 根据key获取缓存中未超时数据。返回相应类型String、Boolean、PlainObject、Array的值。
    */
   const get = (key: string, defaultValue: any = null): any => {
-    return cache.get(prefix.concat(key)) ?? defaultValue
+    return cache.get(prefix.concat(key)) || defaultValue
   }
 
   /**

--- a/web/src/layouts/provider.tsx
+++ b/web/src/layouts/provider.tsx
@@ -24,16 +24,11 @@ export default defineComponent({
       en,
     }
     const userStore = useUserStore()
-    const settingStore = useSettingStore()
     useMenuStore().init()
-    userStore.setLanguage(userStore.getLanguage() ?? 'zh_CN')
     const attrsMerged: any = ref(merge({ locale: locales[userStore.getLanguage()], button: { autoInsertSpace: true } }, attrs))
+
     watch(() => userStore.getLanguage(), (lang: string) => {
       attrsMerged.value.locale = locales[lang]
-    }, { immediate: true })
-
-    watch(() => settingStore.colorMode, async (v) => {
-      await settingStore.toggleColorMode((v === 'auto' ? 'autoModel' : v) as any)
     }, { immediate: true })
 
     onMounted(async () => await usePluginStore().callHooks('setup'))


### PR DESCRIPTION
# 修复
-  缓存获取逻辑错误不返回默认值
-  移除provider中处理语言冗余代码

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
  - 移除了与主题设置相关的逻辑，包括对设置存储的引用和颜色模式切换的处理。

- **行为变更**
  - 缓存钩子的默认值返回逻辑调整，现在当缓存值为任何假值（如 0、false、空字符串等）时，都会返回默认值。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->