### PR TITLE
Fix menu opened

### DIFF
--- a/web/src/layouts/components/menu/index.tsx
+++ b/web/src/layouts/components/menu/index.tsx
@@ -42,6 +42,9 @@ export default defineComponent({
         const index = item.path ?? JSON.stringify(item)
         if (item?.children && item?.children?.length > 0) {
           const indexPath = [index]
+          if (parentPaths.length > 0) {
+            indexPath.push(...parentPaths)
+          }
           subMenus.value[index] = {
             index,
             indexPath,
@@ -50,9 +53,15 @@ export default defineComponent({
           initItems(item.children, indexPath)
         }
         else {
+          const indexPath = [index, ...parentPaths]
+          subMenus.value[index] = {
+            index,
+            indexPath,
+            active: false,
+          }
           items.value[index] = {
             index,
-            indexPath: parentPaths,
+            indexPath,
           }
         }
       })
@@ -63,9 +72,9 @@ export default defineComponent({
         return
       }
       if (props.accordion) {
-        openedMenus.value = openedMenus.value.filter(key => indexPath.includes(key))
+        openedMenus.value = indexPath
       }
-      openedMenus.value.push(index)
+      openedMenus.value.push(...indexPath)
     }
     const closeMenu: MenuInjection['closeMenu'] = async (index) => {
       if (Array.isArray(index)) {
@@ -117,6 +126,7 @@ export default defineComponent({
       if (!activeItem || props.collapse) {
         return
       }
+
       // 展开该菜单项的路径上所有子菜单
       activeItem.indexPath.forEach((index) => {
         const subMenu = subMenus.value[index]

--- a/web/src/layouts/components/menu/sub.tsx
+++ b/web/src/layouts/components/menu/sub.tsx
@@ -102,6 +102,16 @@ export default defineComponent({
         if (menu.children.every((item: any) => item.meta?.menu === false)) {
           flag = false
         }
+        let hiddenLen = 0
+        menu.children.map((item: any) => {
+          if (item.meta?.hidden === true) {
+            hiddenLen++
+          }
+        })
+
+        if (hiddenLen === menu.children.length) {
+          flag = false
+        }
       }
       else {
         flag = false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **修复**
  - 优化菜单项的路径处理方式，提升菜单展开和激活的准确性。
  - 修正子菜单隐藏逻辑，确保当所有子项被隐藏或设置为不显示时，父级菜单不会显示为可展开。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->