### PR TITLE
fix(ma-select-table): 修复单行/多行选中状态判断报错，增强选中判断的安全性

### DIFF
--- a/web/src/components/ma-select-table/index.vue
+++ b/web/src/components/ma-select-table/index.vue
@@ -69,6 +69,15 @@ const options = Object.assign(
 
 const cols = props?.columns ?? []
 
+function isRowSelected(row: any) {
+  if (multiple.value) {
+    return Array.isArray(model.value) && model.value.some(item => item?.[rowKey.value] === row?.[rowKey.value])
+  }
+  else {
+    return model.value?.[rowKey.value] === row?.[rowKey.value]
+  }
+}
+
 watch(() => model.value, () => {
   if (multiple.value && model.value?.length > 0) {
     selectModel.value = model.value.map((item: any) => item[showKey.value])
@@ -119,8 +128,12 @@ onMounted(() => {
         </template>
         <template #column-__selections__="{ row }">
           <div class="flex items-center justify-center">
-            <ma-svg-icon v-if="multiple && model.findIndex((item: any) => item[rowKey] === row[rowKey]) !== -1" name="heroicons:check-16-solid" class="text-green-7" :size="20" />
-            <ma-svg-icon v-else-if="!multiple && model?.[rowKey] === row[rowKey]" name="heroicons:check-16-solid" class="text-green-7" :size="20" />
+            <ma-svg-icon
+              v-if="isRowSelected(row)"
+              name="heroicons:check-16-solid"
+              class="text-green-7"
+              :size="20"
+            />
           </div>
         </template>
       </ma-pro-table>


### PR DESCRIPTION
### 问题描述

`MaSelectTable` 组件中，点击表格行进行选中操作时，未对 `model.value` 进行初始化或类型校验，直接调用 `findIndex` 方法，导致在 `model` 为 `undefined` 的情况下抛出以下错误：
```js
index.vue:124 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'findIndex')
    at index.vue:124:50
    at Proxy.renderFnWithContext (runtime-core.esm-bundler.js:692:13)
    at default (index.es.js:35:204)
    at runtime-core.esm-bundler.js:4466:31
    at Proxy.renderFnWithContext (runtime-core.esm-bundler.js:692:13)
    at column2.renderCell (render-helper.ts:123:32)
    at cellChildren (render-helper.ts:111:19)
    at default (render-helper.ts:106:24)
    at runtime-core.esm-bundler.js:4466:31
    at renderFnWithContext (runtime-core.esm-bundler.js:692:13)
```

### 修改说明

- 在 `onMounted` 中判断 `multiple` 且 `model` 未定义时初始化为 `[]`；
- 在点击行处理逻辑中增加 `model.value` 类型校验；
- 封装 `isRowSelected` 方法用于判断行是否已选中，增强健壮性；
- 修复清空逻辑未正确同步 `model` 和 `selectModel` 的问题；
- 优化组件在单选与多选状态下的表现一致性。

### 影响范围

- 组件：`MaSelectTable.vue`
- 功能：下拉表格选择器

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **优化**
  - 简化了表格中选中行的判断逻辑，提升了多选和单选模式下的使用体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->