### PR TITLE
fix(department)：修复部门管理问题

### DIFF
--- a/web/src/modules/base/views/permission/department/data/getTableColumns.tsx
+++ b/web/src/modules/base/views/permission/department/data/getTableColumns.tsx
@@ -29,7 +29,7 @@ export default function getTableColumns(dialog: UseDialogExpose, formRef: any, t
     { label: () => t('baseDepartment.name'), prop: 'name', align: 'left' },
     { label: () => t('baseDepartment.leaderCount'), prop: 'leader', cellRender: ({ row }) => row.leader?.length ?? 0 },
     { label: () => t('baseDepartment.positionsCount'), prop: 'positions', cellRender: ({ row }) => row.positions?.length ?? 0 },
-    { label: () => t('baseDepartment.usersCount'), prop: 'users', cellRender: ({ row }) => row.users?.length ?? 0 },
+    { label: () => t('baseDepartment.usersCount'), prop: 'users', cellRender: ({ row }) => row.department_users?.length ?? 0 },
     { label: () => t('baseDepartment.created_at'), prop: 'created_at', width: 200 },
     { label: () => t('baseDepartment.updated_at'), prop: 'updated_at', width: 200 },
 

--- a/web/src/modules/base/views/permission/department/index.vue
+++ b/web/src/modules/base/views/permission/department/index.vue
@@ -77,17 +77,8 @@ const maDialog: UseDialogExpose = useDialog({
       maDialog.close()
     }
     else {
-      const elForm = setFormRef.value.maForm.getElFormRef()
-      // 验证通过后
-      elForm.validate().then(() => {
-        // 设置负责人
-        setFormRef.value.saveUserRole().then((res: any) => {
-          res.code === ResultCode.SUCCESS ? msg.success(t('baseUserManage.setRoleSuccess')) : msg.error(res.message)
-          maDialog.close()
-        }).catch((err: any) => {
-          msg.alertError(err)
-        })
-      })
+      proTableRef.value.refresh()
+      maDialog.close()
     }
     okLoadingState(false)
   },

--- a/web/src/modules/base/views/permission/department/setLeader.vue
+++ b/web/src/modules/base/views/permission/department/setLeader.vue
@@ -92,7 +92,7 @@ const options = ref<MaProTableOptions>({
   tableOptions: {
     adaption: false,
     height: 400,
-    rowKey: 'id',
+    rowKey: 'user_id',
     on: {
       // 表格选择事件
       onSelectionChange: (selection: any[]) => selections.value = selection,


### PR DESCRIPTION
### 问题描述

- **部门人员数量统计错误**：部门成员人数计算逻辑异常，显示结果与实际不一致。  
- **负责人选择逻辑错误**：负责人选择弹窗中 `rowKey` 设置错误，导致任意选择一行时所有行被选中。  
- **负责人设置确认报错**：点击负责人设置弹窗的“确认”按钮时报错。

### 修改说明

- 将 `getTableColumns.tsx` 中的 `users` 字段更改为 `department_users`。  
- 将`setLeader.vue`负责人选择中的 `id` 字段改为 `user_id`，与数据结构保持一致。  
- 设置负责人成功后，调用 `proTableRef.value.refresh()` 刷新数据，并关闭弹窗：`maDialog.close()`。

### 影响范围

- 部门人员列表展示逻辑  
- 设置负责人弹窗的交互与数据提交流程  
- 负责人数据字段与选中逻辑的准确性

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 修正了部门用户数统计方式，现在用户数基于 `department_users` 数组计算，显示更准确。
  - 修复了“设置负责人”弹窗在特定表单类型下无需再进行表单校验和保存操作，提升了操作流畅度。
  - 优化了“设置负责人”表格的行唯一标识，从 `id` 改为 `user_id`，避免行识别异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->