### PR TITLE
fix(User): 修复 policy 关系方向错误，改为 hasOne 正确体现一对一关系

### DIFF
--- a/app/Model/Permission/User.php
+++ b/app/Model/Permission/User.php
@@ -19,7 +19,6 @@ use Carbon\Carbon;
 use Hyperf\Collection\Collection;
 use Hyperf\Database\Model\Events\Creating;
 use Hyperf\Database\Model\Events\Deleted;
-use Hyperf\Database\Model\Relations\BelongsTo;
 use Hyperf\Database\Model\Relations\BelongsToMany;
 use Hyperf\Database\Model\Relations\HasOne;
 use Hyperf\DbConnection\Model\Model;

--- a/app/Model/Permission/User.php
+++ b/app/Model/Permission/User.php
@@ -21,6 +21,7 @@ use Hyperf\Database\Model\Events\Creating;
 use Hyperf\Database\Model\Events\Deleted;
 use Hyperf\Database\Model\Relations\BelongsTo;
 use Hyperf\Database\Model\Relations\BelongsToMany;
+use Hyperf\Database\Model\Relations\HasOne;
 use Hyperf\DbConnection\Model\Model;
 
 /**
@@ -144,9 +145,9 @@ final class User extends Model
         return $this->roles()->whereRelation('menus', 'name', $permission)->exists();
     }
 
-    public function policy(): BelongsTo
+    public function policy(): HasOne
     {
-        return $this->belongsTo(Policy::class, 'id', 'user_id');
+        return $this->hasOne(Policy::class, 'user_id', 'id');
     }
 
     public function department(): BelongsToMany


### PR DESCRIPTION
### 变更内容
- 将 `User` 模型中的 `policy()` 关系从 `belongsTo` 改为 `hasOne`。
- 修正外键方向，使用 `hasOne(Policy::class, 'user_id', 'id')`，符合一对一业务逻辑。

### 修改原因
- 从数据库设计看，`user_id` 是 `policy` 表的外键，指向 `user` 表。
- 从业务逻辑看，一个用户拥有一个数据权限策略，属于一对一关系。
- `belongsTo` 用于“从属指向主体”，原写法方向相反，导致无法正确关联和保存。
- 正确应使用 `hasOne` 来表达“用户拥有一个策略”。

### 影响范围
- 影响 `app/Model/Permission/User.php` 文件中的 `policy()` 方法。
- 可能影响依赖该关系的功能模块，如数据权限自动加载、策略更新等。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 用户现在与政策的关联方式已调整为“一对一”关系，提升了数据结构的清晰度和一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->