### PR TITLE
Fix/menu btn permissions

### DIFF
--- a/app/Http/Common/Middleware/RefreshTokenMiddleware.php
+++ b/app/Http/Common/Middleware/RefreshTokenMiddleware.php
@@ -18,6 +18,7 @@ use Mine\JwtAuth\Middleware\AbstractTokenMiddleware;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Swow\Psr7\Message\ServerRequestPlusInterface;
 
 class RefreshTokenMiddleware extends AbstractTokenMiddleware
 {
@@ -26,7 +27,7 @@ class RefreshTokenMiddleware extends AbstractTokenMiddleware
         $this->checkToken->checkJwt($this->parserToken($request));
         return $handler->handle(
             value(
-                static function (ServerRequestInterface $request, UnencryptedToken $token) {
+                static function (ServerRequestPlusInterface $request, UnencryptedToken $token) {
                     return $request->setAttribute('token', $token);
                 },
                 $request,

--- a/app/Http/Common/Middleware/RefreshTokenMiddleware.php
+++ b/app/Http/Common/Middleware/RefreshTokenMiddleware.php
@@ -18,7 +18,6 @@ use Mine\JwtAuth\Middleware\AbstractTokenMiddleware;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Swow\Psr7\Message\ServerRequestPlusInterface;
 
 class RefreshTokenMiddleware extends AbstractTokenMiddleware
 {
@@ -27,7 +26,7 @@ class RefreshTokenMiddleware extends AbstractTokenMiddleware
         $this->checkToken->checkJwt($this->parserToken($request));
         return $handler->handle(
             value(
-                static function (ServerRequestPlusInterface $request, UnencryptedToken $token) {
+                static function (ServerRequestInterface $request, UnencryptedToken $token) {
                     return $request->setAttribute('token', $token);
                 },
                 $request,

--- a/web/src/modules/base/views/permission/menu/menu-form.vue
+++ b/web/src/modules/base/views/permission/menu/menu-form.vue
@@ -38,7 +38,7 @@ function setData(data: Record<string, any>) {
     }
     else if (name === 'children' && data[name]?.length > 0) {
       form.value.btnPermission = []
-      data[name].map((item: any) => {
+      data[name].filter((v: any) => v.meta?.type === 'B').map((item: any) => {
         form.value.btnPermission.push({
           id: item?.id ?? undefined,
           code: item.name,


### PR DESCRIPTION
1. fix(menu-form): 修复菜单按钮权限删除，没有删除对应索引行问题
问题：菜单按钮权限列表点击删除行，没有正确删除行
复现：菜单按钮权限添加多行数据，点击删除第2行，第1行会删除
<img width="1199" alt="image" src="https://github.com/user-attachments/assets/65f2fb75-5b15-46a0-a8d0-8c6cce1ee596" />

2. fix(permission): 修复菜单保存，未更新删除btnPermission 数据项的问题
问题：菜单删除"按钮权限"行数据项，服务端接口没有对btnPermission已删除数据进行处理
复现：菜单按钮权限列表点击删除行，然后保存刷新，数据未被删除
<img width="1204" alt="image" src="https://github.com/user-attachments/assets/d47ef314-6886-4545-b7d3-6103db477473" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 更新菜单项时，按钮权限将与所选数据同步，移除未被保留的按钮权限。

- **修复**
  - 仅将类型为 'B' 的子项作为按钮权限进行处理，提升按钮权限的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->