### PR TITLE
fix(department): 岗位更新后页面未刷新问题

### DIFF
--- a/web/src/modules/base/views/permission/department/index.vue
+++ b/web/src/modules/base/views/permission/department/index.vue
@@ -74,6 +74,7 @@ const maDialog: UseDialogExpose = useDialog({
       }).catch()
     }
     else if (formType === 'position' || formType === 'viewUser') {
+      proTableRef.value.refresh()
       maDialog.close()
     }
     else {


### PR DESCRIPTION
### 问题描述
在部门管理模块中，管理员在修改岗位信息后，页面未能自动刷新，导致用户无法及时看到最新的岗位变更结果，影响操作体验和数据一致性。

### 修改说明
在判断 formType 为 `position` 或 `viewUser` 时，新增调用 `proTableRef.value.refresh()` 方法，确保操作完成后数据表自动刷新。

### 影响范围
- 部门管理页面的岗位编辑功能
- 页面数据刷新逻辑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复了在“岗位”或“查看用户”对话框操作后表格未自动刷新的问题，现在相关操作后表格会自动刷新，确保数据实时更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->