### PR TITLE
update: 升级 vue-i18n 依赖版本至 11.1.6

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -47,7 +47,7 @@
     "sortablejs": "1.15.6",
     "vaul-vue": "^0.3.0",
     "vue": "^3.5.13",
-    "vue-i18n": "^11.1.2",
+    "vue-i18n": "^11.1.6",
     "vue-m-message": "^4.0.2",
     "vue-router": "^4.5.0",
     "vue3-sfc-loader": "^0.9.5",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - 更新了 `vue-i18n` 依赖版本至 ^11.1.6。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->