### PR TITLE
fix(package): 降低vue-i18n版本号

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -47,7 +47,7 @@
     "sortablejs": "1.15.6",
     "vaul-vue": "^0.3.0",
     "vue": "^3.5.13",
-    "vue-i18n": "^11.1.2",
+    "vue-i18n": "11.1.2",
     "vue-m-message": "^4.0.2",
     "vue-router": "^4.5.0",
     "vue3-sfc-loader": "^0.9.5",


### PR DESCRIPTION
## 🐞 问题描述

在启动 MineAdmin-UI 项目时，控制台出现如下错误：
```
SyntaxMirror: Duplicate useI18n calling by local scope. Please don’t call it on local scope
```
该错误由 `vue-i18n` 版本升级引起，某些版本对 `useI18n` 的调用方式有严格限制，导致项目无法正常启动。

---

## 🔧 修改说明

为避免此问题，将 `vue-i18n` 的版本锁定为 `11.1.2`，确保与项目现有结构兼容，避免因版本差异导致启动失败。

```json
"vue-i18n": "11.1.2"
```
---

## 📌 影响范围

- vue-i18n 相关依赖管理。
- 项目启动过程。
- 与国际化相关的组件运行时行为。

该修改可确保 MineAdmin-UI 项目在安装依赖后能稳定运行，无需修改现有代码逻辑。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 固定了 "vue-i18n" 依赖的版本为 11.1.2，不再自动接受兼容的次要或补丁更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->