### PR TITLE
修改swagger文档无效地址，修改不符合docker-compose格式的name

### DIFF
--- a/app/Http/Common/Swagger/Server.php
+++ b/app/Http/Common/Swagger/Server.php
@@ -34,7 +34,7 @@ use Hyperf\Swagger\Annotation as OA;
             description: '演示服务',
         ),
     ],
-    externalDocs: new OA\ExternalDocumentation(description: '开发文档', url: 'https://v3.doc.mineadmin.com')
+    externalDocs: new OA\ExternalDocumentation(description: '开发文档', url: 'https://doc.mineadmin.com')
 )]
 #[OA\SecurityScheme(
     securityScheme: 'Bearer',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-name: MineAdmin
+name: mineadmin
 
 volumes:
   mine_redis_data:


### PR DESCRIPTION
修改swagger文档无效帮助文档地址，修改不符合docker-compose格式的name
`validating D:\dev\mineadmin\docker-compose.yml: name Does not match pattern '^[a-z0-9][a-z0-9_-]*$'
`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新了 OpenAPI 规范中的外部文档链接地址。
* **杂项**
  * Docker Compose 项目名称由 "MineAdmin" 修改为 "mineadmin"。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->