### PR TITLE
fix: 修正 DataScopeAspectTest 的命名空间

### DIFF
--- a/tests/Feature/Library/DataPermission/DataScopeAspectTest.php
+++ b/tests/Feature/Library/DataPermission/DataScopeAspectTest.php
@@ -10,9 +10,8 @@ declare(strict_types=1);
  * @license  https://github.com/mineadmin/MineAdmin/blob/master/LICENSE
  */
 
-namespace HyperfTests\Feature\Library\DataPermission\Aspects;
+namespace HyperfTests\Feature\Library\DataPermission;
 
-use App\Http\CurrentUser;
 use App\Library\DataPermission\Aspects\DataScopeAspect;
 use App\Library\DataPermission\Attribute\DataScope;
 use App\Library\DataPermission\Context as DataPermissionContext;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8aba7fc8-681c-4b19-aa06-864460c45b30)
修复PSR-4 自动加载标准不符合警告

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式**
  * 调整了测试类的命名空间声明，移除了未使用的导入语句。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->