### PR TITLE
ci(swoole): expand swoole 6.x version coverage in test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         php-version: [ '8.3', '8.2', '8.1' ]
-        sw-version: [ 'v5.0.3', 'v5.1.5', 'master' ]
+        sw-version: [ 'v5.0.3', 'v5.1.6', 'v6.0.2', 'master' ]
         exclude:
           - php-version: '8.3'
             sw-version: 'v5.0.3'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 更新了测试工作流，调整了 Swoole 版本的测试范围，包括新增 v5.1.6 和 v6.0.2，移除了 v5.1.5，继续保留对 master 版本的测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->