### PR TITLE
refactor: 重构 utils/handleResize.ts 优化移动端交互逻辑

### DIFF
--- a/web/src/layouts/index.tsx
+++ b/web/src/layouts/index.tsx
@@ -62,7 +62,12 @@ export default defineComponent({
       }
       handleResize(subAsideEl)
     })
-
+    watch(
+      () => route.fullPath,
+      () => {
+        handleResize(subAsideEl)
+      },
+    )
     return () => (
       <div class="app-container">
         <MineHeader />

--- a/web/src/utils/handleResize.ts
+++ b/web/src/utils/handleResize.ts
@@ -8,6 +8,7 @@
  * @Link   https://github.com/mineadmin
  */
 import { useResizeObserver } from '@vueuse/core'
+import useSettingStore from '@/store/modules/useSettingStore.ts'
 
 let listenerBound = false
 
@@ -62,22 +63,28 @@ function isMobileDevice(): boolean {
 function setupSubAsideListener(el: Ref<any>, settingStore: any) {
   const listener = (e: MouseEvent | TouchEvent) => {
     const target = e.target as HTMLElement
-
-    // 获取真实 DOM 元素：组件实例的 $el，或直接是 DOM
     const dom = el.value?.$el ?? el.value
+    // eslint-disable-next-line style/max-statements-per-line
+    if (!dom || !(target instanceof HTMLElement)) { return }
 
-    if (
-      settingStore.getMobileSubmenuState()
-      && dom instanceof HTMLElement
-      && !dom.contains(target)
-    ) {
-      settingStore.setMobileSubmenuState(false)
+    // 点击的是菜单内部
+    if (dom.contains(target)) {
+      const tag = target.tagName.toLowerCase()
+      if (['a', 'span'].includes(tag)) {
+        setTimeout(() => {
+          settingStore.setMobileSubmenuState(false)
+        }, 100)
+      }
+      return
     }
+
+    // 点击菜单外部，立即关闭
+    settingStore.setMobileSubmenuState(false)
   }
 
   if (!listenerBound) {
-    document.addEventListener('mousedown', listener)
-    document.addEventListener('touchstart', listener)
+    document.addEventListener('mousedown', listener, true) // 捕获阶段，防止冒泡后错过
+    document.addEventListener('touchstart', listener, true)
     listenerBound = true
   }
 }

--- a/web/src/utils/handleResize.ts
+++ b/web/src/utils/handleResize.ts
@@ -21,7 +21,6 @@ export default function handleResize(el: Ref<HTMLElement>) {
     updateSearchPanelTop(height)
 
     const isSmallScreen = width < 1024
-    isMobileDevice()
     settingStore.setMobileState(isSmallScreen)
     settingStore.setMobileSubmenuState(!isSmallScreen)
 
@@ -48,19 +47,9 @@ function updateSearchPanelTop(height: number) {
 }
 
 /**
- * 更全面的移动端判断：触摸设备 + UA
- */
-function isMobileDevice(): boolean {
-  return (
-    window.matchMedia('(pointer: coarse)').matches
-    || /android|iphone|ipad|ipod|mobile|tablet/i.test(navigator.userAgent)
-  )
-}
-
-/**
  * 子菜单区域监听 - 始终开启监听，避免多端逻辑错乱
  */
-function setupSubAsideListener(el: Ref<any>, settingStore: any) {
+function setupSubAsideListener(el: Ref<any>, settingStore: ReturnType<typeof useSettingStore>) {
   const listener = (e: MouseEvent | TouchEvent) => {
     const target = e.target as HTMLElement
     const dom = el.value?.$el ?? el.value
@@ -73,7 +62,7 @@ function setupSubAsideListener(el: Ref<any>, settingStore: any) {
       if (['a', 'span'].includes(tag)) {
         setTimeout(() => {
           settingStore.setMobileSubmenuState(false)
-        }, 100)
+        }, 150)
       }
       return
     }

--- a/web/src/utils/handleResize.ts
+++ b/web/src/utils/handleResize.ts
@@ -7,7 +7,7 @@
  * @Author X.Mo<root@imoi.cn>
  * @Link   https://github.com/mineadmin
  */
-import { useMouseInElement, useResizeObserver } from '@vueuse/core'
+import { useResizeObserver } from '@vueuse/core'
 
 let listenerBound = false
 
@@ -59,11 +59,18 @@ function isMobileDevice(): boolean {
 /**
  * 子菜单区域监听 - 始终开启监听，避免多端逻辑错乱
  */
-function setupSubAsideListener(el: Ref<HTMLElement>, settingStore: any) {
-  const { isOutside } = useMouseInElement(el)
+function setupSubAsideListener(el: Ref<any>, settingStore: any) {
+  const listener = (e: MouseEvent | TouchEvent) => {
+    const target = e.target as HTMLElement
 
-  const listener = () => {
-    if (settingStore.getMobileSubmenuState() && isOutside.value) {
+    // 获取真实 DOM 元素：组件实例的 $el，或直接是 DOM
+    const dom = el.value?.$el ?? el.value
+
+    if (
+      settingStore.getMobileSubmenuState()
+      && dom instanceof HTMLElement
+      && !dom.contains(target)
+    ) {
       settingStore.setMobileSubmenuState(false)
     }
   }


### PR DESCRIPTION
## 问题描述
当前 `utils/handleResize.ts` 中在响应式布局下，对移动端与非移动端的判断逻辑不清晰，事件监听缺乏区分处理，导致非移动端在展开子菜单时，只要鼠标移动到空白区域也会触发关闭行为，影响正常使用。

## 修改说明
- 重构了 handleResize.ts 的代码结构，提升了模块职责清晰度
- 优化了设备类型判断逻辑，综合使用触摸能力判断与 UA 识别，提高准确性
- 增强了子菜单关闭判断，确保在移动端外部点击能正确关闭子菜单
- 统一并去重了 resize 与 mousemove 等事件监听器的添加和移除逻辑
- 封装了搜索面板位置的更新函数，增加空值判断避免运行时异常

## 影响范围
- 所有使用 checkMobileSubAside 方法的地方，特别是移动端子菜单的打开/关闭交互逻辑；
- 非移动端子菜单在响应式布局下的行为表现。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **重构**
  * 优化了窗口大小调整和子菜单点击外部自动关闭的处理逻辑，提升了移动端兼容性和界面交互体验。
  * 改进了搜索面板定位逻辑，使界面布局更清晰稳定。
  * 新增路由变化时自动触发窗口调整处理，确保界面状态同步更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->