### PR TITLE
feat(dialog): 优化全屏交互体验，实现全屏状态可控，并增大全屏按钮热区

### DIFF
--- a/web/src/components/ma-dialog/index.vue
+++ b/web/src/components/ma-dialog/index.vue
@@ -21,6 +21,7 @@ const emit = defineEmits<{
 
 const dialogRef = ref<typeof ElDialog>() as Ref<typeof ElDialog>
 const dialogWidth = ref<string>('55%')
+const fullscreen = defineModel<boolean>('fullscreen', { default: false })
 const okLoading = ref<boolean>(false)
 const cancelLoading = ref<boolean>(false)
 const fsIcon = reactive({
@@ -51,22 +52,6 @@ function cancel() {
 
 const { current } = useMagicKeys()
 const keys = computed(() => Array.from(current))
-// 1. 声明 v-model 外部使用-受控状态
-const fullscreen = defineModel<boolean>('fullscreen', { default: false })
-
-// 2. 内部兜底状态-非受控状态
-const innerFullScreen = ref(true)
-
-// 3. 判断父级有没有传全屏 v-model
-const isControlled = computed(() => fullscreen.value !== undefined)
-
-// 4. 统一使用 getter / setter 控制全屏状态
-const isFullscreen = computed({
-  get() { return isControlled.value ? fullscreen.value : innerFullScreen.value },
-  set(v: boolean) {
-    isControlled.value ? (fullscreen.value = v) : (innerFullScreen.value = v)
-  },
-})
 
 watch(() => keys.value, async () => {
   const [one, two] = keys.value
@@ -120,11 +105,11 @@ onMounted(() => {
             {{ $attrs.title ?? '' }}
           </slot>
         </div>
-        <el-link
-          class="el-dialog__headerbtn relative !right-[2px] !-top-[6px]" underline="never"
-          @click="() => isFullscreen = !isFullscreen"
-        >
-          <ma-svg-icon :name="isFullscreen ? fsIcon.exit : fsIcon.todo" :size="15" />
+        <el-link class="el-dialog__headerbtn relative !right-[2px] !-top-[6px]" underline="never" @click="() => fullscreen = !fullscreen">
+          <ma-svg-icon
+            :name="fullscreen ? fsIcon.exit : fsIcon.todo"
+            :size="15"
+          />
         </el-link>
       </div>
     </template>

--- a/web/src/components/ma-dialog/index.vue
+++ b/web/src/components/ma-dialog/index.vue
@@ -21,7 +21,6 @@ const emit = defineEmits<{
 
 const dialogRef = ref<typeof ElDialog>() as Ref<typeof ElDialog>
 const dialogWidth = ref<string>('55%')
-const fullscreen = ref<boolean>(false)
 const okLoading = ref<boolean>(false)
 const cancelLoading = ref<boolean>(false)
 const fsIcon = reactive({
@@ -52,6 +51,22 @@ function cancel() {
 
 const { current } = useMagicKeys()
 const keys = computed(() => Array.from(current))
+// 1. 声明 v-model 外部使用-受控状态
+const fullscreen = defineModel<boolean>('fullscreen', { default: false })
+
+// 2. 内部兜底状态-非受控状态
+const innerFullScreen = ref(true)
+
+// 3. 判断父级有没有传全屏 v-model
+const isControlled = computed(() => fullscreen.value !== undefined)
+
+// 4. 统一使用 getter / setter 控制全屏状态
+const isFullscreen = computed({
+  get() { return isControlled.value ? fullscreen.value : innerFullScreen.value },
+  set(v: boolean) {
+    isControlled.value ? (fullscreen.value = v) : (innerFullScreen.value = v)
+  },
+})
 
 watch(() => keys.value, async () => {
   const [one, two] = keys.value
@@ -105,12 +120,11 @@ onMounted(() => {
             {{ $attrs.title ?? '' }}
           </slot>
         </div>
-        <el-link class="el-dialog__headerbtn relative !right-[2px] !-top-[6px]" underline="never">
-          <ma-svg-icon
-            :name="fullscreen ? fsIcon.exit : fsIcon.todo"
-            :size="15"
-            @click="() => fullscreen = !fullscreen"
-          />
+        <el-link
+          class="el-dialog__headerbtn relative !right-[2px] !-top-[6px]" underline="never"
+          @click="() => isFullscreen = !isFullscreen"
+        >
+          <ma-svg-icon :name="isFullscreen ? fsIcon.exit : fsIcon.todo" :size="15" />
         </el-link>
       </div>
     </template>


### PR DESCRIPTION
## 优化内容：
- 将全屏状态从本地 ref 变量转换为 defineModel 实现双向绑定
- 将点击事件处理从 SVG 图标移至父级 el-link 元素
- 通过向父组件暴露全屏状态提高组件可复用性
- 扩大全屏切换的点击区域，提升用户体验

## 对比
#### 全屏状态管理改进：

旧代码：使用本地 ref 变量 fullscreen 管理全屏状态
新代码：使用 `defineModel<boolean>('fullscreen', { default: false })` 将全屏状态暴露为可双向绑定的 prop，使父组件可以控制和响应对话框的全屏状态

#### 点击事件处理优化：

旧代码：全屏切换点击事件绑定在 SVG 图标上 `@click="() => fullscreen = !fullscreen"`
新代码：点击事件移到了父元素 el-link 上，使点击区域更大，提高了用户体验

这些变更主要提高了组件的可复用性和灵活性，通过将全屏状态作为可双向绑定的 model 暴露出来，使父组件能够更好地控制对话框的行为。同时，点击区域的优化也提升了用户体验。

## 优化前：

https://github.com/user-attachments/assets/16ab6df4-9b8a-4bc9-948b-1b9181d7ac55



## 优化后
https://github.com/user-attachments/assets/212dc7a3-39da-4a73-b273-7a9b761c083a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 对弹窗组件的全屏模式支持外部 v-model 控制，也可内部自管理，提升灵活性和一致性。

* **重构**
  * 优化全屏状态管理，统一受控与非受控场景的处理方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->