### PR TITLE
fix(boring-cyborg): 修正 Logstash 服务路径的大小写错误

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -28,7 +28,7 @@ labelPRBasedOnFilePath:
   Logging:
     - app/Model/UserLoginLog.php
     - app/Model/UserOperationLog.php
-    - app/Service/LogStash/**/*
+    - app/Service/Logstash/**/*
     - app/Repository/Logstash/**/*
   Frontend:
     - web/**/*


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 修正了配置文件中目录名称的大小写，使其与仓库结构保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->