### PR TITLE
feat(app-store): 新增插件下载与安装的提示信息

### DIFF
--- a/web/src/plugins/mine-admin/app-store/style/preview.css
+++ b/web/src/plugins/mine-admin/app-store/style/preview.css
@@ -136,7 +136,6 @@
   flex: 1;
   box-sizing: border-box;
   overflow: auto;
-  padding: 10px 20px;
 }.md-editor-preview {
   font-size: 16px;
   word-break: break-all;

--- a/web/src/plugins/mine-admin/app-store/views/detail.vue
+++ b/web/src/plugins/mine-admin/app-store/views/detail.vue
@@ -9,12 +9,13 @@
 -->
 <script setup lang="ts">
 import type { AppVo } from '../api/app.ts'
-import { download, getDetail, install, unInstall } from '../api/app.ts'
+import { getDetail, unInstall } from '../api/app.ts'
 import versionCompare from '../utils/versionCompare.ts'
 import discount from '../utils/discount.ts'
 import { isUndefined } from 'lodash-es'
 import { useMessage } from '@/hooks/useMessage.ts'
 import { MdPreview } from 'md-editor-v3'
+import { ElMessageBox } from 'element-plus'
 import '../style/preview.css'
 
 const settingStore = useSettingStore()
@@ -75,32 +76,24 @@ function downloadAndInstall() {
     return false
   }
 
-  const body = {
-    identifier: data.value.app?.identifier,
-    version: data.value?.version?.[0]!.version,
-  }
+  const md = `
+    \`\`\`bash
+    # 进入到后端根目录，第一步下载应用
+    php bin/hyperf.php mine-extension:download ${data.value?.app?.identifier}
 
-  dataState.value.buttonLoading = true
-  textState.value.installButtonText = '应用下载中...'
+    # 第二步安装应用
+    php bin/hyperf.php mine-extension:install ${data.value?.app?.identifier}
+    \`\`\`
+    `
 
-  download(body).then(async () => {
-    msg.success('应用下载成功，现在开始安装...')
-    textState.value.installButtonText = '安装应用中...'
-
-    install(body).then(() => {
-      pluginStore.enabled(data.value.app?.identifier)
-      msg.success('应用安装成功，请手动重启后端服务')
-      dataState.value.buttonLoading = false
-      dataState.value.isInstall = true
-    }).catch(() => {
-      msg.error('应用安装失败')
-      textState.value.installButtonText = textState.value.installBtnDefaultText
-      dataState.value.buttonLoading = false
-    })
-  }).catch((e: any) => {
-    textState.value.installButtonText = textState.value.installBtnDefaultText
-    dataState.value.buttonLoading = false
-    msg.alertError(e)
+  ElMessageBox({
+    title: '⚠️ 温馨提示',
+    message: () =>
+      h(MdPreview, {
+        modelValue: md,
+        theme: settingStore.colorMode === 'dark' ? 'dark' : 'light',
+        previewTheme: 'github',
+      }),
   })
 }
 

--- a/web/src/plugins/mine-admin/app-store/views/detail.vue
+++ b/web/src/plugins/mine-admin/app-store/views/detail.vue
@@ -372,7 +372,7 @@ defineExpose({ open })
 :deep(.el-descriptions__cell) {
   @apply flex;
 }
-:deep(.md-editor-code-head, .md-editor-code) {
+:deep(.md-editor-code-head) {
   width: 100%; display: flex;
 }
 :deep(.md-editor-code-lang) {

--- a/web/src/plugins/mine-admin/app-store/views/detail.vue
+++ b/web/src/plugins/mine-admin/app-store/views/detail.vue
@@ -76,21 +76,23 @@ function downloadAndInstall() {
     return false
   }
 
-  const md = `
-    \`\`\`bash
-    # 进入到后端根目录，第一步下载应用
-    php bin/hyperf.php mine-extension:download ${data.value?.app?.identifier}
-
-    # 第二步安装应用
-    php bin/hyperf.php mine-extension:install ${data.value?.app?.identifier}
-    \`\`\`
-    `
+  const md = [
+    '```bash',
+    '# 进入到后端根目录，第一步下载应用',
+    `php bin/hyperf.php mine-extension:download ${data.value?.app?.identifier}`,
+    '',
+    '# 第二步安装应用',
+    `php bin/hyperf.php mine-extension:install ${data.value?.app?.identifier}`,
+    '```',
+  ].join('\n')
 
   ElMessageBox({
     title: '⚠️ 温馨提示',
+    showConfirmButton: false,
     message: () =>
       h(MdPreview, {
         modelValue: md,
+        codeFoldable: false,
         theme: settingStore.colorMode === 'dark' ? 'dark' : 'light',
         previewTheme: 'github',
       }),
@@ -370,7 +372,7 @@ defineExpose({ open })
 :deep(.el-descriptions__cell) {
   @apply flex;
 }
-:deep(.md-editor-code-head) {
+:deep(.md-editor-code-head, .md-editor-code) {
   width: 100%; display: flex;
 }
 :deep(.md-editor-code-lang) {


### PR DESCRIPTION
<img width="1442" height="1056" alt="image" src="https://github.com/user-attachments/assets/bc99ad3e-b6ab-4970-a6ff-9e1537f7388b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **新功能**
  * 应用详情页的“下载并安装”操作现已改为弹窗展示命令行脚本，用户可复制命令手动在后端 CLI 执行安装。

* **样式**
  * 优化了应用预览区域的样式，移除了多余的内边距。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->