### PR TITLE
Update(package): 修正 vue-i18n 版本号前的符号为 ^，以支持更高版本

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -47,7 +47,7 @@
     "sortablejs": "1.15.6",
     "vaul-vue": "^0.3.0",
     "vue": "^3.5.13",
-    "vue-i18n": "11.1.2",
+    "vue-i18n": "^11.1.2",
     "vue-m-message": "^4.0.2",
     "vue-router": "^4.5.0",
     "vue3-sfc-loader": "^0.9.5",

--- a/web/src/hooks/auto-imports/useTrans.ts
+++ b/web/src/hooks/auto-imports/useTrans.ts
@@ -24,6 +24,11 @@ export function useTrans(key: any | null = null): TransType | string | any {
   })
 
   if (key === null) {
+    /**
+     * @deprecated This usage is not recommended. Please use useTrans('key') instead.
+     * Returning both global and local translation functions is discouraged.
+     * This helps avoid duplicate useI18n() calls and improves performance.
+     */
     return {
       localTrans: local.t,
       globalTrans: global.t,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 在翻译相关方法中新增了弃用注释，建议开发者使用推荐的调用方式以提升性能。

* **杂项**
  * 更新了 vue-i18n 依赖版本范围，允许自动获取小版本和补丁更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->