### PR TITLE
feat(e2e): add Playwright configuration and initial tests

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -9,3 +9,4 @@ pnpm-lock.yaml
 .idea*
 types/auto-imports.d.ts
 types/components.d.ts
+tests/e2e/.output/*

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,8 @@
     "lint": "npm-run-all -s lint:tsc lint:eslint lint:stylelint",
     "lint:tsc": "vue-tsc --noEmit",
     "lint:eslint": "eslint . --cache --fix",
-    "lint:stylelint": "stylelint \"src/**/*.{css,scss,vue}\" --cache --fix"
+    "lint:stylelint": "stylelint \"src/**/*.{css,scss,vue}\" --cache --fix",
+    "test:e2e": "playwright test --config=playwright.config.ts"
   },
   "dependencies": {
     "@imengyu/vue3-context-menu": "^1.4.4",
@@ -58,9 +59,11 @@
     "@iconify/json": "^2.2.309",
     "@iconify/vue": "^4.3.0",
     "@intlify/unplugin-vue-i18n": "^6.0.3",
+    "@playwright/test": "^1.54.2",
     "@stylistic/stylelint-config": "^2.0.0",
     "@types/archiver": "^6.0.3",
     "@types/mockjs": "^1.0.10",
+    "@types/node": "^24.1.0",
     "@types/nprogress": "^0.2.3",
     "@types/path-browserify": "^1.0.3",
     "@types/qs": "^6.9.18",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,90 @@
+import { defineConfig, devices } from '@playwright/test'
+import process from 'node:process'
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+const BASE_DIR = 'tests/e2e'
+const OUTPUT_DIR = `${BASE_DIR}/.output`
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: BASE_DIR,
+  /* output directory for test artifacts. */
+  outputDir: `${OUTPUT_DIR}/test-results`,
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: [
+    ['html', { open: 'never', outputFolder: `${OUTPUT_DIR}/html-report` }],
+  ],
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://localhost:2888',
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'retain-on-first-failure',
+    /* Collect video when retrying the failed test. See https://playwright.dev/docs/screenshots */
+    screenshot: 'only-on-failure',
+    /* Collect video when retrying the failed test. See https://playwright.dev/docs/videos */
+    // video: 'retain-on-failure',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+    //
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'pnpm run dev',
+    url: 'http://localhost:2888',
+    reuseExistingServer: !process.env.CI,
+  },
+})

--- a/web/tests/e2e/example.spec.ts
+++ b/web/tests/e2e/example.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test'
+
+test('has title', async ({ page }) => {
+  await page.goto('https://playwright.dev/')
+
+  // Expect a title "to contain" a substring.
+  await expect(page).toHaveTitle(/Playwright/)
+})
+
+test('get started link', async ({ page }) => {
+  await page.goto('https://playwright.dev/')
+
+  // Click the get started link.
+  await page.getByRole('link', { name: 'Get started' }).click()
+
+  // Expects page to have a heading with the name of Installation.
+  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible()
+})

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -4,11 +4,15 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": [
+      "node"
+    ]
   },
   "include": [
     "package.json",
     "vite.config.ts",
-    "vite/**/*.ts"
+    "vite/**/*.ts",
+    "playwright.config.ts"
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 集成了 Playwright 端到端测试框架，新增了相关配置和示例测试用例。
  * 新增 npm 脚本支持一键运行端到端测试。
* **杂项**
  * 更新 .gitignore，忽略端到端测试输出目录。
  * 更新 TypeScript 配置，完善对 Node.js 类型和测试配置文件的支持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->