### PR TITLE
fix(ma-dict-select): 修复 slot 透传并支持自定义 option 渲染

### DIFF
--- a/web/src/components/ma-dict-picker/ma-dict-select.vue
+++ b/web/src/components/ma-dict-picker/ma-dict-select.vue
@@ -81,12 +81,12 @@ const model = defineModel<any>()
     </slot>
 
     <!-- 其他具名插槽 -->
-    <template v-for="slot in Object.keys($slots)" #[slot]="slotProps">
-      <slot
-        v-if="slot !== 'default' && slot !== 'optionDefault'"
-        :name="slot"
-        v-bind="slotProps"
-      />
+    <template
+      v-for="slot in Object.keys($slots).filter(s => s !== 'default' && s !== 'optionDefault')"
+      :key="slot"
+      #[slot]="slotProps"
+    >
+      <slot :name="slot" v-bind="slotProps" />
     </template>
   </el-select>
 </template>

--- a/web/src/components/ma-dict-picker/ma-dict-select.vue
+++ b/web/src/components/ma-dict-picker/ma-dict-select.vue
@@ -81,10 +81,11 @@ const model = defineModel<any>()
     </slot>
 
     <!-- 其他具名插槽 -->
-    <template v-for="slot in Object.keys($slots)" #[slot]>
+    <template v-for="slot in Object.keys($slots)" #[slot]="slotProps">
       <slot
         v-if="slot !== 'default' && slot !== 'optionDefault'"
         :name="slot"
+        v-bind="slotProps"
       />
     </template>
   </el-select>


### PR DESCRIPTION
- **影响范围**: `web/src/components/ma-dict-picker/ma-dict-select.vue`
- **类型**: 修复（兼容增强）

### 变更概述
- **修复 slot 透传问题**：遍历 `Object.keys($slots)`，过滤 `default` 与 `optionDefault`，将其余具名插槽原样透传到内部 `el-select`。
- **支持自定义选项渲染**：新增 `optionDefault` 插槽，分组与普通选项均可自定义渲染。
- **保持兼容**：未提供自定义插槽时，延用原有 label/i18n 渲染逻辑。

### 变更前的问题
- 外部具名插槽（如 `prefix`、`empty` 等）无法在内部 `el-select` 生效。
- 选项行无法统一便捷地进行自定义渲染。

### 变更后的行为
- 所有非默认具名插槽会自动转发到 `el-select`，`prefix`、`empty`、`loading` 等可正常使用。
- 通过 `optionDefault` 插槽可统一自定义选项节点（兼容分组与普通项）。

### 使用示例
```vue
{
      label: '业绩分类',
      prop: 'performance_id',
      render: () => MaDictSelect,
      renderProps: {
        dictName: 'PERF_TYPE',
        // multiple: true,
        clearable: true,
        placeholder: t('form.pleaseInput', { msg: '业绩分类' }),
      },
      renderSlots: {
        optionDefault: ({ option }: { option: any }) => {
          // 自定义显示方式
          return `${option.label} (${option.value})`
        },
        label: ({ label, value }: { label: string, value: any }) => {
          return `${label} (${value})`
        },
      },
    },
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 新功能
  * 动态命名插槽现支持每个插槽的作用域数据（slot props），可在自定义插槽内容中访问当前项信息，默认与 optionDefault 插槽行为保持兼容。

* 改进
  * 渲染更可预测、更新更稳定，便于基于插槽内容进行精细化定制。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->