### PR TITLE
fix: 修复菜单 badge 空值时仍然显示的问题

### DIFF
--- a/web/src/layouts/components/menu/item.tsx
+++ b/web/src/layouts/components/menu/item.tsx
@@ -122,7 +122,7 @@ export default defineComponent({
                         class={{
                           'mine-menu-badge': true,
                           'absolute right-10': (subMenu && !(rootMenu.isMenuPopup && level === 0)),
-                          'hidden': item.meta?.badge === undefined || rootMenu.isMenuPopup,
+                          'hidden': item.meta?.badge === undefined || !item.meta?.badge?.() || rootMenu.isMenuPopup,
                         }}
                       >
                         {item.meta?.badge?.()}


### PR DESCRIPTION
优化菜单徽章显示逻辑，增加对 badge 函数返回值的判断，确保当 badge 返回空值或 falsy 值时正确隐藏徽章显示。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 优化了菜单项中徽章的显示逻辑，现在徽章将在非弹出菜单模式下正确显示。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->