### PR TITLE
支持语言切换时保存用户设置至服务器,修复多语言切换后刷新页面无法正确使用当前语言问题。

### DIFF
--- a/web/src/layouts/components/bars/toolbar/components/translate.tsx
+++ b/web/src/layouts/components/bars/toolbar/components/translate.tsx
@@ -17,10 +17,15 @@ export default defineComponent({
     const settingStore = useSettingStore()
     const locales = userStore.getLocales()
     const { locale, t } = useI18n()
-    function changeLanguage(item: { label: string, value: string }) {
+    async function changeLanguage(item: { label: string, value: string }) {
       userStore.setLanguage(item.value)
+      const appSettings = settingStore.getSettings('app')
+      if (appSettings) {
+        appSettings.useLocale = item.value
+      }
       locale.value = item.value
       settingStore.setTitle(route.meta?.i18n ? t(route.meta?.i18n as string) : route.meta?.title as string)
+      await userStore.saveSettingToSever()
     }
     return () => (
 

--- a/web/src/store/modules/useUserStore.ts
+++ b/web/src/store/modules/useUserStore.ts
@@ -211,16 +211,23 @@ const useUserStore = defineStore(
 
       await nextTick()
       useThemeColor().initThemeColor()
-      const locale = settings?.app?.useLocale ?? (language.value?.trim() || 'zh_CN')
+      const cacheLanguage = cache.get('language', '')?.trim?.() || ''
+      const settingsLanguage = settings?.app?.useLocale?.trim?.() || ''
+      const locale = cacheLanguage || settingsLanguage || 'zh_CN'
+      const appSettings = setting.getSettings('app')
+      if (appSettings) {
+        appSettings.useLocale = locale
+      }
       setLanguage(locale)
     }
 
     function saveSettingToSever() {
       const backend_setting = setting.getSettings()
-      useHttp().post('/admin/permission/update', { backend_setting }).then(() => {
+      return useHttp().post('/admin/permission/update', { backend_setting }).then(() => {
         cache.set('sys_settings', backend_setting)
       }).catch((error) => {
         console.log(error)
+        return Promise.reject(error)
       })
     }
 


### PR DESCRIPTION
如题。修复多语言切换后 刷新 2 遍页面会恢复默认语言的问题。还有刷新页面后请求后端 api 接口时。语言不同步问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 语言设置现已异步保存至服务器，确保用户偏好设置得以持久化。

* **Bug 修复**
  * 优化了语言区域设置的初始化逻辑，改进了相关的错误处理机制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->