### PR TITLE
fix(department): 修复部门成员显示报错

### DIFF
--- a/web/src/modules/base/api/department.ts
+++ b/web/src/modules/base/api/department.ts
@@ -8,10 +8,37 @@
  * @Link   https://github.com/mineadmin
  */
 import type { PageList, ResponseStruct } from '#/global'
+import type { LeaderVo } from '~/base/api/leader.ts'
+import type { PositionVo } from '~/base/api/position.ts'
+
+export interface DepartmentUserPivotVo {
+  dept_id?: number
+  user_id?: number
+}
+
+export interface DepartmentUserVo {
+  id?: number
+  username?: string
+  nickname?: string
+  avatar?: string
+  phone?: string
+  email?: string
+  pivot?: DepartmentUserPivotVo
+  [key: string]: any
+}
 
 export interface DepartmentVo {
   id?: number
   name?: string
+  parent_id?: number | null
+  created_at?: string | null
+  updated_at?: string | null
+  deleted_at?: string | null
+  children?: DepartmentVo[]
+  leader?: LeaderVo[]
+  positions?: PositionVo[]
+  department_users?: DepartmentUserVo[]
+  [key: string]: any
 }
 
 export interface DepartmentSearchVo {

--- a/web/src/modules/base/views/permission/department/viewUser.vue
+++ b/web/src/modules/base/views/permission/department/viewUser.vue
@@ -9,28 +9,24 @@
 -->
 
 <script setup lang="tsx">
-import type { DepartmentVo } from '~/base/api/department.ts'
-import type { MaTableColumns, MaTableOptions } from '@mineadmin/table'
+import type { DepartmentUserVo, DepartmentVo } from '~/base/api/department.ts'
+import type { MaTableColumns, MaTableExpose } from '@mineadmin/table'
 import type { TransType } from '@/hooks/auto-imports/useTrans.ts'
+import useTable from '@/hooks/useTable.ts'
 
 const { data = null } = defineProps<{
   data?: DepartmentVo | null
 }>()
 
-const dictStore = useDictStore()
 const i18n = useTrans() as TransType
 const t = i18n.globalTrans
+const tableRef = ref<MaTableExpose>()
 
-// 参数配置
-const options = ref<MaTableOptions>({
-  data: data?.department_users ?? [],
-  adaption: false,
-  height: 400,
-  rowKey: 'id',
+const tableData = computed<DepartmentUserVo[]>(() => {
+  return Array.isArray(data?.department_users) ? data.department_users : []
 })
 
-// 架构配置
-const tableColumns = ref<MaTableColumns[]>([
+const tableColumns: MaTableColumns[] = [
   {
     label: () => t('baseUserManage.username'),
     prop: 'username',
@@ -48,18 +44,43 @@ const tableColumns = ref<MaTableColumns[]>([
     label: () => t('baseUserManage.email'),
     prop: 'email',
   },
-])
+]
+
+function setTableData(rows: DepartmentUserVo[]) {
+  tableRef.value?.setData(rows)
+}
+
+watch(tableData, (rows) => {
+  setTableData(rows)
+}, { immediate: true })
+
+useTable('tableRef')
+  .then((table: MaTableExpose) => {
+    tableRef.value = table
+    table.setOptions({
+      adaption: false,
+      height: 400,
+      rowKey: 'id',
+    })
+    table.setColumns(tableColumns)
+    setTableData(tableData.value)
+  })
+  .catch((err) => {
+    console.error('init user table failed:', err)
+  })
 </script>
 
 <template>
-  <ma-table :options="options" :columns="tableColumns" />
+  <ma-table ref="tableRef" />
 </template>
 
 <style scoped lang="scss">
 :deep(.mineadmin-pro-table-search) {
-  margin: 0; padding: 0;
+  margin: 0;
+  padding: 0;
   @apply pt-3;
 }
+
 :deep(.mine-card) {
   margin: 0;
 }


### PR DESCRIPTION
## 描述

  本次更新修复了部门管理中“部门成员”查看弹窗的显示报错问题。

  本次修改优化了部门成员数据的表格渲染逻辑，并针对 `department_users` 字段增加了安全兜底处理，避免在接口返回数据为空、结构
  不完整或字段映射不一致时出现运行时报错。同时，补充并校正了部门相关的前端类型定义，使其与接口实际返回结构保持一致，包括部
  门层级数据及成员关联字段，从而提升页面展示的稳定性与代码的可维护性。

## 预期
<img width="1223" height="736" alt="image" src="https://github.com/user-attachments/assets/44e07b40-a037-4d0a-9d76-6bd705990e97" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新特性**
  * 部门数据模型扩展：支持父子层级、时间戳与状态字段，并可展示领导、职位与部门成员等关联信息。

* **优化**
  * 部门用户视图表格重构：采用更可靠的表格初始化与数据绑定机制，实时同步部门成员数据并在初始化失败时记录错误；调整表格选项与样式细节以提升显示与交互体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->