### PR TITLE
fix(department): 更新部门时同步保存基础信息

### DIFF
--- a/app/Service/Permission/DepartmentService.php
+++ b/app/Service/Permission/DepartmentService.php
@@ -44,6 +44,7 @@ class DepartmentService extends IService
             if (empty($entity)) {
                 throw new BusinessException(ResultCode::NOT_FOUND);
             }
+            $this->repository->updateById($id, $data);
             $this->handleEntity($entity, $data);
         });
     }


### PR DESCRIPTION
## 变更说明

  修复部门编辑时基础信息无法更新到数据表的问题。

  在原有逻辑中，编辑部门时仅处理了关联数据（如部门成员、负责人等），但缺少对部门基础字段的持久化更新，导致名称、上级部门、
  状态等基础信息提交后未正确写入数据库。

  本次调整在 `DepartmentService::updateById()` 中补充了基础信息更新逻辑，在处理关联关系前先执行：

  ```php
  $this->repository->updateById($id, $data);

  确保编辑部门时，基础信息与关联数据都能够被正确保存。

  ## 影响范围

  - 部门编辑功能
  - 部门基础信息更新流程

  ## 修复结果

  - 编辑部门时，基础信息可以正确更新到数据表
  - 原有的部门成员、负责人等关联数据处理逻辑保持不变

  ## 验证建议

  1. 进入部门管理页面，编辑某个部门
  2. 修改部门基础信息，例如名称、状态、排序或上级部门
  3. 保存后检查页面回显及数据库记录
  4. 确认基础信息已正确更新，同时关联数据未受影响

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化部门信息更新时的数据持久化逻辑，确保关系数据同步前已正确保存，提高数据完整性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->