### PR TITLE
修复菜单从编辑切回「新增顶级菜单」保存会出现错误弹窗

### DIFF
--- a/web/src/modules/base/views/permission/menu/menu-form.vue
+++ b/web/src/modules/base/views/permission/menu/menu-form.vue
@@ -53,9 +53,7 @@ function setData(data: Record<string, any>) {
     }
   })
 
-  if (data.id) {
-    form.value.dataType = 'edit'
-  }
+  form.value.dataType = data.id ? 'edit' : 'add';
 }
 
 const inputVisible = ref <Record<string, boolean>>({


### PR DESCRIPTION
修复菜单从编辑切回「新增顶级菜单」时， 保存会出现错误弹窗：此操作已执行过，请点击左侧菜单重新操作。

修复内容：
```JavaScript
 if (data.id) {
    form.value.dataType = 'edit'
 }
// 改为
form.value.dataType = data.id ? 'edit' : 'add';
```

复现操作：菜单管理 -> 新增顶级菜单 -> （点击任意树菜单）-> 新增顶级菜单 -> 填写数据保存 -> 出现错误弹窗

<img width="1187" height="902" alt="image" src="https://github.com/user-attachments/assets/30638559-ec1e-471c-9b19-b5af6c384ed2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 修复

* 优化了权限菜单表单的状态管理逻辑。在添加和编辑操作中，表单模式的设置现在更加明确和可靠，确保在所有使用场景下都能正确初始化和处理表单数据。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->